### PR TITLE
refactor: extract reusable LinkList component from settings page

### DIFF
--- a/apps/sandbox/src/app/(tabs)/settings/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/index.tsx
@@ -1,59 +1,12 @@
-import { Ionicons } from "@expo/vector-icons";
-import { Link, type LinkProps } from "expo-router";
-import { FlatList, Pressable, StyleSheet, Text } from "react-native";
-import { useThemeContext } from "../../../theme/ThemeContext";
+import { LinkList, type LinkItem } from "../../../components/LinkList";
 
 const list = [
   {
     href: "/settings/theme",
     text: "テーマ",
   },
-] as const satisfies ItemProps[];
+] as const satisfies LinkItem[];
 
 export default function SettingsScreen() {
-  const { theme } = useThemeContext();
-
-  return (
-    <FlatList
-      data={list}
-      renderItem={({ item }) => <Item {...item} />}
-      keyExtractor={(item) => item.href}
-      contentContainerStyle={styles.container}
-      style={{ backgroundColor: theme.colors.background }}
-    />
-  );
+  return <LinkList data={list} />;
 }
-
-type ItemProps = {
-  href: LinkProps["href"];
-  text: string;
-};
-
-export function Item({ href, text }: ItemProps) {
-  const { theme } = useThemeContext();
-
-  return (
-    <Link href={href} asChild>
-      <Pressable style={styles.item}>
-        <Text style={[styles.itemText, { color: theme.colors.text }]}>
-          {text}
-        </Text>
-        <Ionicons name="chevron-forward" size={20} color={theme.colors.text} />
-      </Pressable>
-    </Link>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: {
-    padding: 16,
-  },
-  item: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  itemText: {
-    fontSize: 20,
-  },
-});

--- a/apps/sandbox/src/components/LinkList.tsx
+++ b/apps/sandbox/src/components/LinkList.tsx
@@ -1,0 +1,58 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Link, type LinkProps } from "expo-router";
+import type { ReactElement } from "react";
+import { FlatList, Pressable, StyleSheet, Text } from "react-native";
+import { useThemeContext } from "../theme/ThemeContext";
+
+export type LinkItem = {
+  href: LinkProps["href"];
+  text: string;
+};
+
+type LinkListProps = {
+  data: readonly LinkItem[];
+};
+
+export function LinkList({ data }: LinkListProps): ReactElement {
+  const { theme } = useThemeContext();
+
+  return (
+    <FlatList
+      data={data}
+      renderItem={({ item }) => <LinkListItem {...item} />}
+      keyExtractor={(item) => item.href.toString()}
+      contentContainerStyle={styles.container}
+      style={{ backgroundColor: theme.colors.background }}
+    />
+  );
+}
+
+function LinkListItem({ href, text }: LinkItem): ReactElement {
+  const { theme } = useThemeContext();
+
+  return (
+    <Link href={href} asChild>
+      <Pressable style={styles.item}>
+        <Text style={[styles.itemText, { color: theme.colors.text }]}>
+          {text}
+        </Text>
+        <Ionicons name="chevron-forward" size={20} color={theme.colors.text} />
+      </Pressable>
+    </Link>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 0,
+  },
+  item: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: 16,
+  },
+  itemText: {
+    fontSize: 20,
+  },
+});


### PR DESCRIPTION
- Create generic LinkList component for navigation lists
- Move link list rendering logic to components directory
- Update settings page to use new LinkList component
- Enable reuse of link list pattern across other pages

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
