### PR TITLE
refactor: LinkListコンポーネントを専用ディレクトリに移動

### DIFF
--- a/apps/sandbox/src/app/(tabs)/settings/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/index.tsx
@@ -1,4 +1,7 @@
-import { LinkList, type LinkItem } from "../../../components/LinkList";
+import {
+  LinkList,
+  type LinkItem,
+} from "../../../components/link-list/LinkList";
 
 const list = [
   {

--- a/apps/sandbox/src/components/link-list/LinkList.tsx
+++ b/apps/sandbox/src/components/link-list/LinkList.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Link, type LinkProps } from "expo-router";
 import type { ReactElement } from "react";
 import { FlatList, Pressable, StyleSheet, Text } from "react-native";
-import { useThemeContext } from "../theme/ThemeContext";
+import { useThemeContext } from "../../theme/ThemeContext";
 
 export type LinkItem = {
   href: LinkProps["href"];


### PR DESCRIPTION
## Summary
- LinkListコンポーネントを専用ディレクトリ `src/components/link-list/` に移動しました
- コンポーネントの整理とプロジェクト構造の改善を目的としています

## 変更内容
- `src/components/LinkList.tsx` → `src/components/link-list/LinkList.tsx` に移動
- インポートパスを更新
  - `settings/index.tsx`: 新しいパスからLinkListをインポート
  - `LinkList.tsx`: ThemeContextへの相対パスを修正
- barrel file (index.tsx) を使用せず、明示的なファイル名を維持

## Test plan
- [x] リンターのエラーがないことを確認
- [ ] アプリケーションが正常に起動することを確認
- [ ] 設定画面のLinkListが正しく表示されることを確認
- [ ] テーマ設定画面への遷移が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)