### PR TITLE
feat: ホーム画面をリスト表示に変更

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/index.tsx
@@ -1,40 +1,15 @@
-import { StyleSheet, Text, View } from "react-native";
-import { Link } from "expo-router";
-import { useThemeContext } from "../../../theme/ThemeContext";
+import {
+  LinkList,
+  type LinkItem,
+} from "../../../components/link-list/LinkList";
+
+const list = [
+  {
+    href: "/navigation-patterns",
+    text: "Navigation Patterns",
+  },
+] as const satisfies LinkItem[];
 
 export default function Index() {
-  const { theme } = useThemeContext();
-
-  return (
-    <View
-      style={[styles.container, { backgroundColor: theme.colors.background }]}
-    >
-      <Text style={[styles.text, { color: theme.colors.text }]}>
-        Welcome to the app!
-      </Text>
-      <Link
-        href="/navigation-patterns"
-        style={[styles.link, { color: theme.colors.primary }]}
-      >
-        Go to Navigation Patterns
-      </Link>
-    </View>
-  );
+  return <LinkList data={list} />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  text: {
-    fontSize: 18,
-    fontWeight: "500",
-    marginBottom: 20,
-  },
-  link: {
-    fontSize: 16,
-    textDecorationLine: "underline",
-  },
-});


### PR DESCRIPTION
## Summary
- ホーム画面のUIを設定画面と同様のリスト形式に統一
- `LinkList`コンポーネントを使用して一貫性のあるUIを実現
- 将来的に機能を追加しやすい構造に変更

## Test plan
- [ ] アプリを起動してホーム画面が正しく表示されることを確認
- [ ] 「Navigation Patterns」のリンクが正しく動作することを確認
- [ ] ライトモード/ダークモードの両方で適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)