### PR TITLE
feat: navigation-patternsページをルートレベルに移動

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/_layout.tsx
@@ -15,10 +15,6 @@ export default function HomeLayout() {
       }}
     >
       <Stack.Screen name="index" options={{ title: "Home" }} />
-      <Stack.Screen
-        name="navigation-patterns"
-        options={{ title: "Navigation Patterns" }}
-      />
     </Stack>
   );
 }

--- a/apps/sandbox/src/app/_layout.tsx
+++ b/apps/sandbox/src/app/_layout.tsx
@@ -9,7 +9,14 @@ function RootLayoutContent() {
     <>
       <StatusBar style={isDark ? "light" : "dark"} />
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen
+          name="(tabs)"
+          options={{ headerShown: false, title: "Home" }}
+        />
+        <Stack.Screen
+          name="navigation-patterns"
+          options={{ title: "Navigation Patterns" }}
+        />
       </Stack>
     </>
   );

--- a/apps/sandbox/src/app/navigation-patterns.tsx
+++ b/apps/sandbox/src/app/navigation-patterns.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, Text, View, ScrollView } from "react-native";
 import { Link } from "expo-router";
-import { useThemeContext } from "../../../theme/ThemeContext";
+import { useThemeContext } from "../theme/ThemeContext";
 
 export default function NavigationPatterns() {
   const { theme } = useThemeContext();


### PR DESCRIPTION
## Summary
- navigation-patternsページをタブナビゲーターの外側（ルートレベル）に移動しました
- 戻るボタンのラベルを "(tabs)" から "Home" に改善しました

## Changes
- `apps/sandbox/src/app/(tabs)/(home)/navigation-patterns.tsx` → `apps/sandbox/src/app/navigation-patterns.tsx` に移動
- ルートStack Navigatorに navigation-patterns のScreen定義を追加
- (tabs) 画面のtitleを "Home" に設定（戻るボタンのラベル改善）
- Homeタブのレイアウトから navigation-patterns のScreen定義を削除

## Test plan
- [ ] アプリを起動して、ホーム画面から "Navigation Patterns" をタップ
- [ ] navigation-patterns ページがフルスクリーンで表示されることを確認
- [ ] ヘッダーの戻るボタンのラベルが "Home" と表示されることを確認
- [ ] 戻るボタンでホーム画面に戻れることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)