### PR TITLE
feat: modal・formSheetプレゼンテーションのサンプルページを追加

### DIFF
--- a/apps/sandbox/src/app/_layout.tsx
+++ b/apps/sandbox/src/app/_layout.tsx
@@ -15,7 +15,7 @@ function RootLayoutContent() {
         />
         <Stack.Screen
           name="navigation-patterns"
-          options={{ title: "Navigation Patterns" }}
+          options={{ headerShown: false }}
         />
       </Stack>
     </>

--- a/apps/sandbox/src/app/navigation-patterns/_layout.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/_layout.tsx
@@ -1,8 +1,19 @@
 import { Stack } from "expo-router";
+import { useThemeContext } from "../../theme/ThemeContext";
 
 export default function NavigationPatternsLayout() {
+  const { theme } = useThemeContext();
+
   return (
-    <Stack>
+    <Stack
+      screenOptions={{
+        headerStyle: {
+          backgroundColor: theme.colors.card,
+        },
+        headerTintColor: theme.colors.text,
+        headerShadowVisible: !theme.dark,
+      }}
+    >
       <Stack.Screen
         name="index"
         options={{

--- a/apps/sandbox/src/app/navigation-patterns/_layout.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/_layout.tsx
@@ -1,0 +1,40 @@
+import { Stack } from "expo-router";
+
+export default function NavigationPatternsLayout() {
+  return (
+    <Stack>
+      <Stack.Screen
+        name="index"
+        options={{
+          title: "Navigation Patterns",
+        }}
+      />
+      <Stack.Screen
+        name="modal"
+        options={{
+          title: "Modal Sample",
+        }}
+      />
+      <Stack.Screen
+        name="form-sheet"
+        options={{
+          title: "Form Sheet Sample",
+        }}
+      />
+      <Stack.Screen
+        name="modal-screen"
+        options={{
+          title: "Modal Screen",
+          presentation: "modal",
+        }}
+      />
+      <Stack.Screen
+        name="form-sheet-screen"
+        options={{
+          title: "Form Sheet Screen",
+          presentation: "formSheet",
+        }}
+      />
+    </Stack>
+  );
+}

--- a/apps/sandbox/src/app/navigation-patterns/form-sheet-screen.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/form-sheet-screen.tsx
@@ -1,0 +1,262 @@
+import {
+  StyleSheet,
+  Text,
+  View,
+  Pressable,
+  ScrollView,
+  TextInput,
+  Platform,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { useThemeContext } from "../../theme/ThemeContext";
+import { useState } from "react";
+
+export default function FormSheetScreen() {
+  const { theme } = useThemeContext();
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = () => {
+    // In a real app, you would handle form submission here
+    router.back();
+  };
+
+  const handleCancel = () => {
+    router.back();
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: theme.colors.text }]}>
+          Form Sheet Example
+        </Text>
+        <View style={styles.headerButtons}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.headerButton,
+              pressed && styles.headerButtonPressed,
+            ]}
+            onPress={handleCancel}
+          >
+            <Text
+              style={[styles.cancelButtonText, { color: theme.colors.text }]}
+            >
+              Cancel
+            </Text>
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [
+              styles.headerButton,
+              pressed && styles.headerButtonPressed,
+            ]}
+            onPress={handleSubmit}
+          >
+            <Text
+              style={[styles.doneButtonText, { color: theme.colors.primary }]}
+            >
+              Done
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.content}>
+        <Text style={[styles.subtitle, { color: theme.colors.text }]}>
+          {Platform.OS === "ios"
+            ? "Form Sheet Presentation"
+            : "Modal Form (Android)"}
+        </Text>
+
+        <Text style={[styles.description, { color: theme.colors.text }]}>
+          This demonstrates a form presented in a{" "}
+          {Platform.OS === "ios" ? "form sheet" : "modal"}.
+          {Platform.OS === "ios" &&
+            " Notice how you can see the parent screen in the background."}
+        </Text>
+
+        <View style={styles.form}>
+          <View style={styles.formGroup}>
+            <Text style={[styles.label, { color: theme.colors.text }]}>
+              Name
+            </Text>
+            <TextInput
+              style={[
+                styles.input,
+                {
+                  backgroundColor: theme.colors.card,
+                  color: theme.colors.text,
+                  borderColor: theme.colors.border,
+                },
+              ]}
+              value={name}
+              onChangeText={setName}
+              placeholder="Enter your name"
+              placeholderTextColor={theme.colors.text + "80"}
+            />
+          </View>
+
+          <View style={styles.formGroup}>
+            <Text style={[styles.label, { color: theme.colors.text }]}>
+              Email
+            </Text>
+            <TextInput
+              style={[
+                styles.input,
+                {
+                  backgroundColor: theme.colors.card,
+                  color: theme.colors.text,
+                  borderColor: theme.colors.border,
+                },
+              ]}
+              value={email}
+              onChangeText={setEmail}
+              placeholder="Enter your email"
+              placeholderTextColor={theme.colors.text + "80"}
+              keyboardType="email-address"
+              autoCapitalize="none"
+            />
+          </View>
+
+          <View style={styles.formGroup}>
+            <Text style={[styles.label, { color: theme.colors.text }]}>
+              Message
+            </Text>
+            <TextInput
+              style={[
+                styles.textArea,
+                {
+                  backgroundColor: theme.colors.card,
+                  color: theme.colors.text,
+                  borderColor: theme.colors.border,
+                },
+              ]}
+              value={message}
+              onChangeText={setMessage}
+              placeholder="Enter your message"
+              placeholderTextColor={theme.colors.text + "80"}
+              multiline
+              numberOfLines={4}
+            />
+          </View>
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.submitButton,
+              {
+                backgroundColor: pressed
+                  ? theme.colors.primaryLight
+                  : theme.colors.primary,
+              },
+            ]}
+            onPress={handleSubmit}
+          >
+            <Text style={styles.submitButtonText}>Submit Form</Text>
+          </Pressable>
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 10,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "bold",
+  },
+  headerButtons: {
+    flexDirection: "row",
+    gap: 15,
+  },
+  headerButton: {
+    paddingHorizontal: 15,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  headerButtonPressed: {
+    backgroundColor: "rgba(0,0,0,0.1)",
+  },
+  cancelButtonText: {
+    fontSize: 16,
+  },
+  doneButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  content: {
+    padding: 20,
+  },
+  subtitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 10,
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 25,
+  },
+  form: {
+    marginBottom: 30,
+  },
+  formGroup: {
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: "500",
+    marginBottom: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 15,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  textArea: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 15,
+    paddingVertical: 12,
+    fontSize: 16,
+    minHeight: 100,
+    textAlignVertical: "top",
+  },
+  buttonContainer: {
+    alignItems: "center",
+  },
+  submitButton: {
+    paddingHorizontal: 30,
+    paddingVertical: 15,
+    borderRadius: 8,
+    alignItems: "center",
+    minWidth: 200,
+  },
+  submitButtonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/apps/sandbox/src/app/navigation-patterns/form-sheet.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/form-sheet.tsx
@@ -1,0 +1,132 @@
+import { StyleSheet, Text, View, Pressable, Platform } from "react-native";
+import { useRouter } from "expo-router";
+import { useThemeContext } from "../../theme/ThemeContext";
+
+export default function FormSheetSample() {
+  const { theme } = useThemeContext();
+  const router = useRouter();
+
+  const openFormSheet = () => {
+    router.push("/navigation-patterns/form-sheet-screen");
+  };
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+    >
+      <View style={styles.content}>
+        <Text style={[styles.title, { color: theme.colors.text }]}>
+          Form Sheet Presentation Sample
+        </Text>
+
+        <Text style={[styles.description, { color: theme.colors.text }]}>
+          Tap the button below to open a screen with form sheet presentation.
+        </Text>
+
+        <Pressable
+          style={({ pressed }) => [
+            styles.button,
+            {
+              backgroundColor: pressed
+                ? theme.colors.primaryLight
+                : theme.colors.primary,
+            },
+          ]}
+          onPress={openFormSheet}
+        >
+          <Text style={styles.buttonText}>Open Form Sheet</Text>
+        </Pressable>
+
+        <View style={styles.infoBox}>
+          <Text style={[styles.infoTitle, { color: theme.colors.text }]}>
+            About Form Sheet Presentation:
+          </Text>
+          <Text style={[styles.infoText, { color: theme.colors.text }]}>
+            •{" "}
+            {Platform.OS === "ios"
+              ? "Smaller modal that doesn't cover the entire screen"
+              : "On Android, behaves like a regular modal"}
+            {"\n"}•{" "}
+            {Platform.OS === "ios"
+              ? "Shows parent screen in the background"
+              : "Covers the entire screen on Android"}
+            {"\n"}•{" "}
+            {Platform.OS === "ios"
+              ? "Ideal for forms and focused tasks"
+              : "Platform-specific behavior"}
+            {"\n"}• Can be dismissed with swipe down gesture
+          </Text>
+        </View>
+
+        {Platform.OS === "android" && (
+          <View
+            style={[
+              styles.noteBox,
+              { backgroundColor: theme.colors.primaryLight },
+            ]}
+          >
+            <Text style={[styles.noteText, { color: theme.colors.text }]}>
+              Note: Form sheet presentation is iOS-specific. On Android, it will
+              display as a regular modal.
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 10,
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 30,
+    lineHeight: 24,
+  },
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    marginBottom: 30,
+  },
+  buttonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  infoBox: {
+    padding: 15,
+    backgroundColor: "rgba(0,0,0,0.05)",
+    borderRadius: 8,
+    marginBottom: 20,
+  },
+  infoTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 10,
+  },
+  infoText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  noteBox: {
+    padding: 15,
+    borderRadius: 8,
+    opacity: 0.9,
+  },
+  noteText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/apps/sandbox/src/app/navigation-patterns/index.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/index.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, Text, View, ScrollView } from "react-native";
 import { Link } from "expo-router";
-import { useThemeContext } from "../theme/ThemeContext";
+import { useThemeContext } from "../../theme/ThemeContext";
 
 export default function NavigationPatterns() {
   const { theme } = useThemeContext();
@@ -29,15 +29,37 @@ export default function NavigationPatterns() {
         </View>
 
         <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
+            Presentation Styles:
+          </Text>
+
+          <Link
+            href="/navigation-patterns/modal"
+            style={[styles.link, { color: theme.colors.primary }]}
+          >
+            Modal Presentation
+          </Link>
+
+          <Link
+            href="/navigation-patterns/form-sheet"
+            style={[styles.link, { color: theme.colors.primary }]}
+          >
+            Form Sheet Presentation
+          </Link>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
+            Other Navigation Examples:
+          </Text>
+
           <Link
             href="/settings"
             style={[styles.link, { color: theme.colors.primary }]}
           >
             Go to Settings Tab
           </Link>
-        </View>
 
-        <View style={styles.section}>
           <Link
             href="/settings/theme"
             style={[styles.link, { color: theme.colors.primary }]}
@@ -85,6 +107,7 @@ const styles = StyleSheet.create({
   link: {
     fontSize: 16,
     textDecorationLine: "underline",
-    paddingVertical: 5,
+    paddingVertical: 8,
+    marginVertical: 2,
   },
 });

--- a/apps/sandbox/src/app/navigation-patterns/modal-screen.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/modal-screen.tsx
@@ -1,0 +1,168 @@
+import { StyleSheet, Text, View, Pressable, ScrollView } from "react-native";
+import { useRouter } from "expo-router";
+import { useThemeContext } from "../../theme/ThemeContext";
+
+export default function ModalScreen() {
+  const { theme } = useThemeContext();
+  const router = useRouter();
+
+  const closeModal = () => {
+    router.back();
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: theme.colors.text }]}>
+          Modal Screen
+        </Text>
+        <Pressable
+          style={({ pressed }) => [
+            styles.closeButton,
+            {
+              backgroundColor: pressed ? "rgba(0,0,0,0.1)" : "transparent",
+            },
+          ]}
+          onPress={closeModal}
+        >
+          <Text
+            style={[styles.closeButtonText, { color: theme.colors.primary }]}
+          >
+            Close
+          </Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.content}>
+        <Text style={[styles.subtitle, { color: theme.colors.text }]}>
+          This is a modal presentation
+        </Text>
+
+        <Text style={[styles.description, { color: theme.colors.text }]}>
+          This screen was presented using the modal presentation style. You can
+          dismiss it by:
+        </Text>
+
+        <View style={styles.list}>
+          <Text style={[styles.listItem, { color: theme.colors.text }]}>
+            • Tapping the &quot;Close&quot; button
+          </Text>
+          <Text style={[styles.listItem, { color: theme.colors.text }]}>
+            • Swiping down from the top (iOS)
+          </Text>
+          <Text style={[styles.listItem, { color: theme.colors.text }]}>
+            • Using the back gesture (Android)
+          </Text>
+        </View>
+
+        <View
+          style={[
+            styles.demoBox,
+            { backgroundColor: theme.colors.primaryLight },
+          ]}
+        >
+          <Text style={[styles.demoTitle, { color: theme.colors.text }]}>
+            Demo Content
+          </Text>
+          <Text style={[styles.demoText, { color: theme.colors.text }]}>
+            This modal can contain any content like forms, images, or
+            interactive elements.
+          </Text>
+        </View>
+
+        <Pressable
+          style={({ pressed }) => [
+            styles.primaryButton,
+            {
+              backgroundColor: pressed
+                ? theme.colors.primaryLight
+                : theme.colors.primary,
+            },
+          ]}
+          onPress={closeModal}
+        >
+          <Text style={styles.primaryButtonText}>Done</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  contentContainer: {
+    flexGrow: 1,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 10,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+  },
+  closeButton: {
+    paddingHorizontal: 15,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  closeButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  content: {
+    padding: 20,
+  },
+  subtitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 15,
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 20,
+  },
+  list: {
+    marginBottom: 30,
+  },
+  listItem: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginBottom: 5,
+  },
+  demoBox: {
+    padding: 20,
+    borderRadius: 12,
+    marginBottom: 30,
+  },
+  demoTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 10,
+  },
+  demoText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  primaryButton: {
+    paddingHorizontal: 30,
+    paddingVertical: 15,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  primaryButtonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});

--- a/apps/sandbox/src/app/navigation-patterns/modal.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/modal.tsx
@@ -1,0 +1,98 @@
+import { StyleSheet, Text, View, Pressable } from "react-native";
+import { useRouter } from "expo-router";
+import { useThemeContext } from "../../theme/ThemeContext";
+
+export default function ModalSample() {
+  const { theme } = useThemeContext();
+  const router = useRouter();
+
+  const openModal = () => {
+    router.push("/navigation-patterns/modal-screen");
+  };
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+    >
+      <View style={styles.content}>
+        <Text style={[styles.title, { color: theme.colors.text }]}>
+          Modal Presentation Sample
+        </Text>
+
+        <Text style={[styles.description, { color: theme.colors.text }]}>
+          Tap the button below to open a screen with modal presentation.
+        </Text>
+
+        <Pressable
+          style={({ pressed }) => [
+            styles.button,
+            {
+              backgroundColor: pressed
+                ? theme.colors.primaryLight
+                : theme.colors.primary,
+            },
+          ]}
+          onPress={openModal}
+        >
+          <Text style={styles.buttonText}>Open Modal</Text>
+        </Pressable>
+
+        <View style={styles.infoBox}>
+          <Text style={[styles.infoTitle, { color: theme.colors.text }]}>
+            About Modal Presentation:
+          </Text>
+          <Text style={[styles.infoText, { color: theme.colors.text }]}>
+            • Covers the entire screen{"\n"}• Animates from bottom to top{"\n"}•
+            Can be dismissed with swipe down gesture{"\n"}• Blocks interaction
+            with the parent screen
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 10,
+  },
+  description: {
+    fontSize: 16,
+    marginBottom: 30,
+    lineHeight: 24,
+  },
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    marginBottom: 30,
+  },
+  buttonText: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  infoBox: {
+    padding: 15,
+    backgroundColor: "rgba(0,0,0,0.05)",
+    borderRadius: 8,
+  },
+  infoTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 10,
+  },
+  infoText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});


### PR DESCRIPTION
## Summary
- navigation-patternsページにmodal、formSheetの2つのプレゼンテーションスタイルのサンプルを実装
- 各プレゼンテーションスタイルの動作確認と説明を含むデモページを追加
- iOSとAndroidでのプラットフォーム別の挙動の違いについても説明を追加
- navigation-patternsのヘッダーにテーマ（ライト/ダーク）を適用

## 変更内容
- `navigation-patterns`を単一ファイルからディレクトリ構造に変更
- modal presentation: フルスクリーンモーダルのサンプル
- formSheet presentation: iOS特有のフォームシート表示のサンプル（Androidではモーダルとして表示）
- 各プレゼンテーションスタイルのデモ画面を追加
- navigation-patternsの_layout.tsxにテーマベースのヘッダースタイルを追加

## Test plan
- [ ] アプリを起動して、Navigation Patternsページに遷移できることを確認
- [ ] Modal Presentationリンクをタップして、モーダル画面が表示されることを確認
- [ ] Form Sheet Presentationリンクをタップして、フォームシート画面が表示されることを確認
- [ ] 各画面で「Close」ボタンまたはスワイプで画面を閉じられることを確認
- [ ] iOSとAndroidで動作確認（特にformSheetの挙動の違い）
- [ ] ライト/ダークモードを切り替えて、navigation-patternsのヘッダーが適切なテーマで表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)