### PR TITLE
refactor: /navigation-patternsページをLinkListコンポーネントを使用したリスト形式に変更

### DIFF
--- a/apps/sandbox/src/app/navigation-patterns/index.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/index.tsx
@@ -1,113 +1,16 @@
-import { StyleSheet, Text, View, ScrollView } from "react-native";
-import { Link } from "expo-router";
-import { useThemeContext } from "../../theme/ThemeContext";
+import { LinkList, type LinkItem } from "../../components/link-list/LinkList";
+
+const list = [
+  {
+    href: "/navigation-patterns/modal",
+    text: "Modal Presentation",
+  },
+  {
+    href: "/navigation-patterns/form-sheet",
+    text: "Form Sheet Presentation",
+  },
+] as const satisfies LinkItem[];
 
 export default function NavigationPatterns() {
-  const { theme } = useThemeContext();
-
-  return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: theme.colors.background }]}
-    >
-      <View style={styles.content}>
-        <Text style={[styles.title, { color: theme.colors.text }]}>
-          Navigation Patterns
-        </Text>
-
-        <Text style={[styles.description, { color: theme.colors.text }]}>
-          This screen demonstrates navigation patterns in Expo Router with
-          nested navigators.
-        </Text>
-
-        <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
-            Current Route Structure:
-          </Text>
-          <Text style={[styles.code, { color: theme.colors.text }]}>
-            /navigation-patterns
-          </Text>
-        </View>
-
-        <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
-            Presentation Styles:
-          </Text>
-
-          <Link
-            href="/navigation-patterns/modal"
-            style={[styles.link, { color: theme.colors.primary }]}
-          >
-            Modal Presentation
-          </Link>
-
-          <Link
-            href="/navigation-patterns/form-sheet"
-            style={[styles.link, { color: theme.colors.primary }]}
-          >
-            Form Sheet Presentation
-          </Link>
-        </View>
-
-        <View style={styles.section}>
-          <Text style={[styles.sectionTitle, { color: theme.colors.text }]}>
-            Other Navigation Examples:
-          </Text>
-
-          <Link
-            href="/settings"
-            style={[styles.link, { color: theme.colors.primary }]}
-          >
-            Go to Settings Tab
-          </Link>
-
-          <Link
-            href="/settings/theme"
-            style={[styles.link, { color: theme.colors.primary }]}
-          >
-            Go directly to Theme Settings
-          </Link>
-        </View>
-      </View>
-    </ScrollView>
-  );
+  return <LinkList data={list} />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  content: {
-    padding: 20,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: "bold",
-    marginBottom: 10,
-  },
-  description: {
-    fontSize: 16,
-    marginBottom: 20,
-    lineHeight: 24,
-  },
-  section: {
-    marginVertical: 15,
-  },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: "600",
-    marginBottom: 5,
-  },
-  code: {
-    fontFamily: "monospace",
-    fontSize: 14,
-    padding: 10,
-    backgroundColor: "rgba(0,0,0,0.05)",
-    borderRadius: 5,
-  },
-  link: {
-    fontSize: 16,
-    textDecorationLine: "underline",
-    paddingVertical: 8,
-    marginVertical: 2,
-  },
-});


### PR DESCRIPTION
## Summary
- `/navigation-patterns`ページを`LinkList`コンポーネントを使用したリスト形式に変更
- `/settings`ページと同様のUIに統一し、一貫性を向上
- リンク先を`/navigation-patterns/`配下のみに限定

## Test plan
- [ ] `/navigation-patterns`ページが正しく表示される
- [ ] リンクが正しく機能する
- [ ] テーマ切り替え時にスタイルが適切に反映される

🤖 Generated with [Claude Code](https://claude.ai/code)