### PR TITLE
feat: 各画面の日本語化

### DIFF
--- a/apps/sandbox/src/app/(tabs)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/_layout.tsx
@@ -24,7 +24,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: "Home",
+          title: "ホーム",
           tabBarIcon: ({ color }) => (
             <FontAwesome size={28} name="home" color={color} />
           ),
@@ -33,7 +33,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="settings"
         options={{
-          title: "Settings",
+          title: "設定",
           headerShown: false,
           tabBarIcon: ({ color }) => (
             <FontAwesome size={28} name="cog" color={color} />

--- a/apps/sandbox/src/app/(tabs)/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { LinkList, type LinkItem } from "../../components/link-list/LinkList";
 const list = [
   {
     href: "/navigation-patterns",
-    text: "Navigation Patterns",
+    text: "ナビゲーションパターン",
   },
 ] as const satisfies LinkItem[];
 

--- a/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
@@ -14,8 +14,8 @@ export default function SettingsLayout() {
         headerShadowVisible: !theme.dark,
       }}
     >
-      <Stack.Screen name="index" options={{ title: "Settings" }} />
-      <Stack.Screen name="theme" options={{ title: "Theme" }} />
+      <Stack.Screen name="index" options={{ title: "設定" }} />
+      <Stack.Screen name="theme" options={{ title: "テーマ" }} />
     </Stack>
   );
 }

--- a/apps/sandbox/src/app/navigation-patterns/_layout.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/_layout.tsx
@@ -17,32 +17,32 @@ export default function NavigationPatternsLayout() {
       <Stack.Screen
         name="index"
         options={{
-          title: "Navigation Patterns",
+          title: "ナビゲーションパターン",
         }}
       />
       <Stack.Screen
         name="modal"
         options={{
-          title: "Modal Sample",
+          title: "モーダルサンプル",
         }}
       />
       <Stack.Screen
         name="form-sheet"
         options={{
-          title: "Form Sheet Sample",
+          title: "フォームシートサンプル",
         }}
       />
       <Stack.Screen
         name="modal-screen"
         options={{
-          title: "Modal Screen",
+          title: "モーダル画面",
           presentation: "modal",
         }}
       />
       <Stack.Screen
         name="form-sheet-screen"
         options={{
-          title: "Form Sheet Screen",
+          title: "フォームシート画面",
           presentation: "formSheet",
           sheetGrabberVisible: true,
         }}

--- a/apps/sandbox/src/app/navigation-patterns/form-sheet-screen.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/form-sheet-screen.tsx
@@ -38,7 +38,7 @@ export default function FormSheetScreen() {
       >
         <View style={styles.header}>
           <Text style={[styles.title, { color: theme.colors.text }]}>
-            Form Sheet Example
+            フォームシートの例
           </Text>
           <View style={styles.headerButtons}>
             <Pressable
@@ -51,7 +51,7 @@ export default function FormSheetScreen() {
               <Text
                 style={[styles.cancelButtonText, { color: theme.colors.text }]}
               >
-                Cancel
+                キャンセル
               </Text>
             </Pressable>
             <Pressable
@@ -64,7 +64,7 @@ export default function FormSheetScreen() {
               <Text
                 style={[styles.doneButtonText, { color: theme.colors.primary }]}
               >
-                Done
+                完了
               </Text>
             </Pressable>
           </View>
@@ -73,21 +73,21 @@ export default function FormSheetScreen() {
         <View style={styles.content}>
           <Text style={[styles.subtitle, { color: theme.colors.text }]}>
             {Platform.OS === "ios"
-              ? "Form Sheet Presentation"
-              : "Modal Form (Android)"}
+              ? "フォームシート表示"
+              : "モーダルフォーム（Android）"}
           </Text>
 
           <Text style={[styles.description, { color: theme.colors.text }]}>
-            This demonstrates a form presented in a{" "}
-            {Platform.OS === "ios" ? "form sheet" : "modal"}.
+            これは {Platform.OS === "ios" ? "フォームシート" : "モーダル"}
+            で表示されたフォームのデモです。
             {Platform.OS === "ios" &&
-              " Notice how you can see the parent screen in the background."}
+              "背景に親画面が見えることに注目してください。"}
           </Text>
 
           <View style={styles.form}>
             <View style={styles.formGroup}>
               <Text style={[styles.label, { color: theme.colors.text }]}>
-                Name
+                名前
               </Text>
               <TextInput
                 style={[
@@ -100,14 +100,14 @@ export default function FormSheetScreen() {
                 ]}
                 value={name}
                 onChangeText={setName}
-                placeholder="Enter your name"
+                placeholder="名前を入力"
                 placeholderTextColor={theme.colors.text + "80"}
               />
             </View>
 
             <View style={styles.formGroup}>
               <Text style={[styles.label, { color: theme.colors.text }]}>
-                Email
+                メールアドレス
               </Text>
               <TextInput
                 style={[
@@ -120,7 +120,7 @@ export default function FormSheetScreen() {
                 ]}
                 value={email}
                 onChangeText={setEmail}
-                placeholder="Enter your email"
+                placeholder="メールアドレスを入力"
                 placeholderTextColor={theme.colors.text + "80"}
                 keyboardType="email-address"
                 autoCapitalize="none"
@@ -129,7 +129,7 @@ export default function FormSheetScreen() {
 
             <View style={styles.formGroup}>
               <Text style={[styles.label, { color: theme.colors.text }]}>
-                Message
+                メッセージ
               </Text>
               <TextInput
                 style={[
@@ -142,7 +142,7 @@ export default function FormSheetScreen() {
                 ]}
                 value={message}
                 onChangeText={setMessage}
-                placeholder="Enter your message"
+                placeholder="メッセージを入力"
                 placeholderTextColor={theme.colors.text + "80"}
                 multiline
                 numberOfLines={4}
@@ -162,7 +162,7 @@ export default function FormSheetScreen() {
               ]}
               onPress={handleSubmit}
             >
-              <Text style={styles.submitButtonText}>Submit Form</Text>
+              <Text style={styles.submitButtonText}>フォームを送信</Text>
             </Pressable>
           </View>
         </View>

--- a/apps/sandbox/src/app/navigation-patterns/form-sheet.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/form-sheet.tsx
@@ -16,11 +16,11 @@ export default function FormSheetSample() {
     >
       <View style={styles.content}>
         <Text style={[styles.title, { color: theme.colors.text }]}>
-          Form Sheet Presentation Sample
+          フォームシート表示サンプル
         </Text>
 
         <Text style={[styles.description, { color: theme.colors.text }]}>
-          Tap the button below to open a screen with form sheet presentation.
+          下のボタンをタップしてフォームシート表示で画面を開きます。
         </Text>
 
         <Pressable
@@ -34,27 +34,27 @@ export default function FormSheetSample() {
           ]}
           onPress={openFormSheet}
         >
-          <Text style={styles.buttonText}>Open Form Sheet</Text>
+          <Text style={styles.buttonText}>フォームシートを開く</Text>
         </Pressable>
 
         <View style={styles.infoBox}>
           <Text style={[styles.infoTitle, { color: theme.colors.text }]}>
-            About Form Sheet Presentation:
+            フォームシート表示について：
           </Text>
           <Text style={[styles.infoText, { color: theme.colors.text }]}>
             •{" "}
             {Platform.OS === "ios"
-              ? "Smaller modal that doesn't cover the entire screen"
-              : "On Android, behaves like a regular modal"}
+              ? "画面全体を覆わない小さめのモーダル"
+              : "Androidでは通常のモーダルとして動作"}
             {"\n"}•{" "}
             {Platform.OS === "ios"
-              ? "Shows parent screen in the background"
-              : "Covers the entire screen on Android"}
+              ? "背景に親画面を表示"
+              : "Androidでは画面全体を覆います"}
             {"\n"}•{" "}
             {Platform.OS === "ios"
-              ? "Ideal for forms and focused tasks"
-              : "Platform-specific behavior"}
-            {"\n"}• Can be dismissed with swipe down gesture
+              ? "フォームや集中的なタスクに最適"
+              : "プラットフォーム固有の動作"}
+            {"\n"}• 下へのスワイプジェスチャーで閉じることができます
           </Text>
         </View>
 
@@ -63,8 +63,8 @@ export default function FormSheetSample() {
             style={[styles.noteBox, { backgroundColor: theme.colors.card }]}
           >
             <Text style={[styles.noteText, { color: theme.colors.text }]}>
-              Note: Form sheet presentation is iOS-specific. On Android, it will
-              display as a regular modal.
+              注意：フォームシート表示はiOS固有です。Androidでは通常のモーダルとして
+              表示されます。
             </Text>
           </View>
         )}

--- a/apps/sandbox/src/app/navigation-patterns/index.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/index.tsx
@@ -3,11 +3,11 @@ import { LinkList, type LinkItem } from "../../components/link-list/LinkList";
 const list = [
   {
     href: "/navigation-patterns/modal",
-    text: "Modal Presentation",
+    text: "モーダル表示",
   },
   {
     href: "/navigation-patterns/form-sheet",
-    text: "Form Sheet Presentation",
+    text: "フォームシート表示",
   },
 ] as const satisfies LinkItem[];
 

--- a/apps/sandbox/src/app/navigation-patterns/modal-screen.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/modal-screen.tsx
@@ -17,7 +17,7 @@ export default function ModalScreen() {
     >
       <View style={styles.header}>
         <Text style={[styles.title, { color: theme.colors.text }]}>
-          Modal Screen
+          モーダル画面
         </Text>
         <Pressable
           style={({ pressed }) => [
@@ -31,40 +31,40 @@ export default function ModalScreen() {
           <Text
             style={[styles.closeButtonText, { color: theme.colors.primary }]}
           >
-            Close
+            閉じる
           </Text>
         </Pressable>
       </View>
 
       <View style={styles.content}>
         <Text style={[styles.subtitle, { color: theme.colors.text }]}>
-          This is a modal presentation
+          これはモーダル表示です
         </Text>
 
         <Text style={[styles.description, { color: theme.colors.text }]}>
-          This screen was presented using the modal presentation style. You can
-          dismiss it by:
+          この画面はモーダル表示スタイルで表示されています。
+          以下の方法で閉じることができます：
         </Text>
 
         <View style={styles.list}>
           <Text style={[styles.listItem, { color: theme.colors.text }]}>
-            • Tapping the &quot;Close&quot; button
+            • 「閉じる」ボタンをタップ
           </Text>
           <Text style={[styles.listItem, { color: theme.colors.text }]}>
-            • Swiping down from the top (iOS)
+            • 上から下へスワイプ（iOS）
           </Text>
           <Text style={[styles.listItem, { color: theme.colors.text }]}>
-            • Using the back gesture (Android)
+            • 戻るジェスチャーを使用（Android）
           </Text>
         </View>
 
         <View style={[styles.demoBox, { backgroundColor: theme.colors.card }]}>
           <Text style={[styles.demoTitle, { color: theme.colors.text }]}>
-            Demo Content
+            デモコンテンツ
           </Text>
           <Text style={[styles.demoText, { color: theme.colors.text }]}>
-            This modal can contain any content like forms, images, or
-            interactive elements.
+            このモーダルにはフォーム、画像、インタラクティブな要素など、
+            あらゆるコンテンツを含めることができます。
           </Text>
         </View>
 
@@ -79,7 +79,7 @@ export default function ModalScreen() {
           ]}
           onPress={closeModal}
         >
-          <Text style={styles.primaryButtonText}>Done</Text>
+          <Text style={styles.primaryButtonText}>完了</Text>
         </Pressable>
       </View>
     </ScrollView>

--- a/apps/sandbox/src/app/navigation-patterns/modal.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/modal.tsx
@@ -16,11 +16,11 @@ export default function ModalSample() {
     >
       <View style={styles.content}>
         <Text style={[styles.title, { color: theme.colors.text }]}>
-          Modal Presentation Sample
+          モーダル表示サンプル
         </Text>
 
         <Text style={[styles.description, { color: theme.colors.text }]}>
-          Tap the button below to open a screen with modal presentation.
+          下のボタンをタップしてモーダル表示で画面を開きます。
         </Text>
 
         <Pressable
@@ -34,17 +34,17 @@ export default function ModalSample() {
           ]}
           onPress={openModal}
         >
-          <Text style={styles.buttonText}>Open Modal</Text>
+          <Text style={styles.buttonText}>モーダルを開く</Text>
         </Pressable>
 
         <View style={styles.infoBox}>
           <Text style={[styles.infoTitle, { color: theme.colors.text }]}>
-            About Modal Presentation:
+            モーダル表示について：
           </Text>
           <Text style={[styles.infoText, { color: theme.colors.text }]}>
-            • Covers the entire screen{"\n"}• Animates from bottom to top{"\n"}•
-            Can be dismissed with swipe down gesture{"\n"}• Blocks interaction
-            with the parent screen
+            • 画面全体を覆います{"\n"}• 下から上へアニメーションします{"\n"}•
+            下へのスワイプジェスチャーで閉じることができます{"\n"}•
+            親画面との対話をブロックします
           </Text>
         </View>
       </View>


### PR DESCRIPTION
## 概要
アプリケーション内のすべての画面で英語テキストを日本語に翻訳しました。

## 変更内容
### タブナビゲーション
- Home → ホーム
- Settings → 設定

### 画面タイトル
- Navigation Patterns → ナビゲーションパターン
- Modal Sample → モーダルサンプル
- Form Sheet Sample → フォームシートサンプル
- Modal Screen → モーダル画面
- Form Sheet Screen → フォームシート画面

### UIテキスト
- ボタンテキスト（Open Modal → モーダルを開く、Close → 閉じる、Done → 完了、Cancel → キャンセル等）
- 説明文をすべて日本語化
- フォームのラベルとプレースホルダー（Name → 名前、Email → メールアドレス、Message → メッセージ）

## 技術的な詳細
- 技術用語（Modal、Form Sheet、iOS、Android、presentation等）は実装で使用される用語のため英語のまま保持
- 一般的なUIテキストのみを日本語化
- すべての変更はPrettierでフォーマット済み
- ESLintのチェックをパス

## テスト
- [x] `pnpm lint` でリントが通ることを確認
- [x] `pnpm format` でコードフォーマットを実行

🤖 Generated with [Claude Code](https://claude.ai/code)