### PR TITLE
refactor: Type Assertionを型ガードに置き換え

### DIFF
--- a/apps/sandbox/src/i18n.ts
+++ b/apps/sandbox/src/i18n.ts
@@ -25,9 +25,19 @@ export function initI18n(locale: Locale = defaultLocale) {
   i18n.loadAndActivate({ locale, messages });
 }
 
+// ロケールの型ガード
+function isValidLocale(locale: string): locale is Locale {
+  return locale in locales;
+}
+
 // 現在のロケールを取得
 export function getCurrentLocale(): Locale {
-  return i18n.locale as Locale;
+  const currentLocale = i18n.locale;
+  if (isValidLocale(currentLocale)) {
+    return currentLocale;
+  }
+  // 不正なロケールの場合はデフォルトロケールを返す
+  return defaultLocale;
 }
 
 // ロケールを変更


### PR DESCRIPTION
## Summary
- i18n.tsで使用していたType Assertion (`as Locale`) を型ガード関数に置き換えました
- より安全で型安全な実装に改善しました

## Changes
- `isValidLocale`型ガード関数を追加
- `getCurrentLocale`関数でType Assertionの代わりに型ガードを使用
- 不正なロケールの場合はデフォルトロケールを返すエラーハンドリングを追加

## Test plan
- [x] 型チェックが通ることを確認 (`pnpm -C apps/sandbox typecheck`)
- [x] リントが通ることを確認 (`pnpm -C apps/sandbox lint`)
- [ ] アプリケーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)