### PR TITLE
feat: GitHub ActionsのNode.js/pnpmセットアップをcomposite actionに抽出

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,36 @@
+name: 'Setup Node.js and pnpm'
+description: 'Setup Node.js, pnpm, and install dependencies'
+
+inputs:
+  node-version:
+    description: 'Version of Node.js to use'
+    required: false
+    default: 'lts/*'
+  pnpm-version:
+    description: 'Version of pnpm to use'
+    required: false
+    default: 'latest'
+  install-deps:
+    description: 'Whether to install dependencies'
+    required: false
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      if: inputs.install-deps == 'true'
+      run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: 'Version of Node.js to use'
     required: false
     default: 'lts/*'
-  pnpm-version:
-    description: 'Version of pnpm to use'
-    required: false
-    default: 'latest'
   install-deps:
     description: 'Whether to install dependencies'
     required: false
@@ -21,7 +17,6 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: ${{ inputs.pnpm-version }}
         run_install: false
 
     - name: Setup Node.js

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node
 
       - name: Run ESLint
         run: pnpm -C apps/sandbox lint:expo
@@ -45,19 +34,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node
 
       - name: Generate typed routes
         run: pnpm -C apps/sandbox generate-types

--- a/.github/workflows/lingui-check.yaml
+++ b/.github/workflows/lingui-check.yaml
@@ -15,19 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node
 
       - name: Run lingui extract
         run: pnpm -C apps/sandbox lingui:extract


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローで重複していたNode.js/pnpmのセットアップコードをcomposite actionに抽出
- `setup-node`という名前の再利用可能なactionを作成
- 既存のワークフロー（ci.yaml、lingui-check.yaml）を更新して新しいactionを使用

## 変更内容
### 新規作成
- `.github/actions/setup-node/action.yml` - pnpm、Node.js、依存関係のインストールを行うcomposite action

### 更新
- `.github/workflows/ci.yaml` - lintとtypecheckジョブでcomposite actionを使用
- `.github/workflows/lingui-check.yaml` - lingui-checkジョブでcomposite actionを使用

## 効果
- コードの重複を削減（40行削除、43行追加）
- セットアップ手順の一元管理により保守性が向上
- 将来的な変更時に1箇所の修正で済む

## Test plan
- [ ] GitHub ActionsのCIが正常に動作することを確認
- [ ] lintジョブが成功することを確認
- [ ] typecheckジョブが成功することを確認
- [ ] lingui-checkジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)