### PR TITLE
Intl APIのPolyfillを追加してLinguiの高度な機能をサポート

### DIFF
--- a/LINGUI_LEARNING_PLAN.md
+++ b/LINGUI_LEARNING_PLAN.md
@@ -56,19 +56,19 @@
   - [x] 階層的な命名規則の決定
   - [x] 既存キーのリファクタリング
 
-### フェーズ6: IntlのPolyfill設定（6日目）
-- [ ] Intl APIのPolyfill要件の理解
-  - [ ] React NativeでのIntl APIサポート状況の確認
-  - [ ] 必要なPolyfillパッケージの調査
-  - [ ] パフォーマンスへの影響評価
-- [ ] 必要なパッケージのインストール
-  - [ ] `@formatjs/intl-locale`のインストール
-  - [ ] `@formatjs/intl-pluralrules`のインストール
-  - [ ] 日本語・英語のlocale-dataの追加
-- [ ] Polyfillの実装
-  - [ ] `_layout.tsx`へのPolyfillインポート追加
-  - [ ] polyfill-forceを使用した最適化
-  - [ ] 動作確認とバンドルサイズの測定
+### フェーズ6: IntlのPolyfill設定（6日目）✅
+- [x] Intl APIのPolyfill要件の理解
+  - [x] React NativeでのIntl APIサポート状況の確認
+  - [x] 必要なPolyfillパッケージの調査
+  - [x] パフォーマンスへの影響評価
+- [x] 必要なパッケージのインストール
+  - [x] `@formatjs/intl-locale`のインストール
+  - [x] `@formatjs/intl-pluralrules`のインストール
+  - [x] 日本語・英語のlocale-dataの追加
+- [x] Polyfillの実装
+  - [x] `_layout.tsx`へのPolyfillインポート追加
+  - [x] polyfill-forceを使用した最適化
+  - [x] 動作確認とバンドルサイズの測定
 
 ### フェーズ7: Pluralマクロの学習（7日目）
 - [ ] `plural`マクロの基礎学習
@@ -357,8 +357,24 @@ Lingui公式ドキュメントによると、**モバイルアプリでの言語
   - コードの一貫性を保つことの重要性
   - Generated IDsは条件分岐の実装方法に関わらず適切に動作
 
-### フェーズ6完了時のメモ（予定）
-- IntlのPolyfillに関する学習内容と実装結果を記録予定
+### フェーズ6完了時のメモ（2025-08-13）
+- **必要なパッケージ**：
+  - `@formatjs/intl-locale`: Intl.Locale APIのpolyfill
+  - `@formatjs/intl-pluralrules`: Intl.PluralRules APIのpolyfill（plural/selectOrdinalマクロに必要）
+- **実装内容**：
+  - `_layout.tsx`の最上部（他のインポートより前）にPolyfillを追加
+  - `polyfill-force`版を使用（環境チェックをスキップして初期化時間を短縮）
+  - 日本語と英語のlocale-dataを明示的にインポート
+- **技術的背景**：
+  - React Native（特にHermes）はすべてのIntl APIをネイティブサポートしていない
+  - Linguiの高度な機能（plural、selectOrdinalマクロ）はこれらのAPIに依存
+  - Lingui公式ドキュメント（08/2024時点）でもPolyfillが必要と明記
+- **パフォーマンスへの配慮**：
+  - `polyfill-force`により低スペック端末での初期化時間を改善
+  - バンドルサイズへの影響はあるが、i18n機能には必須
+- **注意点**：
+  - 新しい言語を追加する際は、対応するlocale-dataのインポートも必要
+  - Polyfillインポートは他のすべてのインポートより前に配置することが重要
 
 ---
 

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
+    "@formatjs/intl-locale": "^4.2.11",
+    "@formatjs/intl-pluralrules": "^5.4.4",
     "@lingui/core": "^5.3.3",
     "@lingui/macro": "^5.3.3",
     "@lingui/react": "^5.3.3",

--- a/apps/sandbox/src/app/_layout.tsx
+++ b/apps/sandbox/src/app/_layout.tsx
@@ -1,3 +1,10 @@
+// Intl APIのPolyfill（React Native向け）
+// 他のインポートより前に配置する必要がある
+import "@formatjs/intl-locale/polyfill-force";
+import "@formatjs/intl-pluralrules/polyfill-force";
+import "@formatjs/intl-pluralrules/locale-data/ja"; // 日本語のlocale data
+import "@formatjs/intl-pluralrules/locale-data/en"; // 英語のlocale data
+
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { I18nProvider } from "@lingui/react";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       '@expo/vector-icons':
         specifier: ^14.1.0
         version: 14.1.0(expo-font@13.3.2(expo@53.0.20(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.5(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@formatjs/intl-locale':
+        specifier: ^4.2.11
+        version: 4.2.11
+      '@formatjs/intl-pluralrules':
+        specifier: ^5.4.4
+        version: 5.4.4
       '@lingui/core':
         specifier: ^5.3.3
         version: 5.3.3(@lingui/babel-plugin-lingui-macro@5.3.3(babel-plugin-macros@3.1.0)(typescript@5.8.3))(babel-plugin-macros@3.1.0)
@@ -938,6 +944,27 @@ packages:
   '@expo/xcpretty@4.3.2':
     resolution: {integrity: sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw==}
     hasBin: true
+
+  '@formatjs/ecma402-abstract@2.3.4':
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/intl-enumerator@1.8.10':
+    resolution: {integrity: sha512-/iDm5v5809LN6GiEwT7gU/0lVuKbpyRh3l9USL205mi1kcunvY8eo4mooNr/3/cV4zWG9aUuPwrzukgSCaYlcg==}
+
+  '@formatjs/intl-getcanonicallocales@2.5.5':
+    resolution: {integrity: sha512-sxosgiLSGhf3So3hf4nk223G+qxWEZytAWVmgwuK5k16698N6jMbndzLL0R51i54aTTIp+UyIC+VKjns2eil3w==}
+
+  '@formatjs/intl-locale@4.2.11':
+    resolution: {integrity: sha512-8OtGsxPawRF8D6I9SPVhoS/tNSAD0KO/9BywbaP3YNHeoI3qxsK7IR0bN7BCjW6qHZZD7U3VnXVHHteVk12zMA==}
+
+  '@formatjs/intl-localematcher@0.6.1':
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+
+  '@formatjs/intl-pluralrules@5.4.4':
+    resolution: {integrity: sha512-PdxoTmqaIh9c/zMR6Hw6+avrEh0b0giYlF4S4KOUjmWHUfDFj/8BqKVFFyQx1QInsRWhjdRWumqKYrcsjogDwg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2096,6 +2123,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -5538,6 +5568,44 @@ snapshots:
       find-up: 5.0.0
       js-yaml: 4.1.0
 
+  '@formatjs/ecma402-abstract@2.3.4':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-enumerator@1.8.10':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      tslib: 2.8.1
+
+  '@formatjs/intl-getcanonicallocales@2.5.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-locale@4.2.11':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/intl-enumerator': 1.8.10
+      '@formatjs/intl-getcanonicallocales': 2.5.5
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/intl-pluralrules@5.4.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -7003,6 +7071,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-uri-component@0.2.2: {}
 
   deep-extend@0.6.0: {}
@@ -7255,14 +7325,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.30.1(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.36.0(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3)
       eslint: 9.30.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.30.1(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -7286,7 +7355,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.30.1(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.35.1(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.30.1(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.36.0(eslint@9.30.1(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.30.1(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9519,8 +9588,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## 概要
Lingui学習計画のフェーズ6を実施し、React NativeでLinguiの高度な機能（plural、selectOrdinalマクロ）を使用できるようにIntl APIのPolyfillを追加しました。

## 変更内容
- 🔧 `@formatjs/intl-locale`と`@formatjs/intl-pluralrules`パッケージを追加
- 📝 `_layout.tsx`の最上部にPolyfillインポートを追加
  - `polyfill-force`版を使用して低スペック端末での初期化時間を改善
  - 日本語と英語のlocale-dataを明示的にインポート
- 📚 LINGUI_LEARNING_PLAN.mdにフェーズ6の実装内容と学習メモを追記

## 技術的背景
React Native（特にHermesエンジン）はすべてのIntl APIをネイティブサポートしていないため、Linguiの高度な機能を使用するにはPolyfillが必要です。Lingui公式ドキュメント（2024年8月時点）でも推奨されている実装方法に従いました。

## テスト項目
- [x] アプリが正常に起動することを確認
- [x] lint/typecheckがパスすることを確認
- [x] 既存の翻訳機能が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)