### PR TITLE
feat: lingui extractコマンドに--cleanオプションを追加

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -14,7 +14,7 @@
     "format": "prettier . --write",
     "generate-types": "expo customize tsconfig.json",
     "typecheck": "tsc --noEmit",
-    "lingui:extract": "lingui extract"
+    "lingui:extract": "lingui extract --clean"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- `lingui:extract`スクリプトに`--clean`オプションを追加しました
- 古い未使用のメッセージが自動的にクリーンアップされるようになります

## Test plan
- [ ] `pnpm -C apps/sandbox lingui:extract`を実行して正常に動作することを確認
- [ ] 未使用のメッセージが削除されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)