### PR TITLE
build: react-native-workletsをtrustPolicyExcludeに追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,5 @@ minimumReleaseAge: 1440
 blockExoticSubdeps: true
 # lockfileに記載されたパッケージの信頼レベルが以前のリリースより低下した場合にインストールを拒否
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  - 'react-native-worklets@0.7.2'


### PR DESCRIPTION
## 概要

`react-native-worklets@0.7.2`を`trustPolicyExclude`に追加し、`pnpm install`時の`ERR_PNPM_TRUST_DOWNGRADE`エラーを解消する。

## 背景・動機

`react-native-worklets`のnightlyビルドはGitHub Actions（Trusted Publisher + Provenance付き）で公開されているのに対し、安定版は開発者が手動で公開しておりProvenanceが付与されていない。このリリースフローの違いにより、pnpmの`trustPolicy: no-downgrade`が信頼レベルの低下と判断してインストールをブロックしていた。

## アプローチ

npm registryの公開者情報（`_npmUser`）やメンテナー一覧を確認し、Software Mansionの正規リリースであることを確認した上で`trustPolicyExclude`に追加。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)