### PR TITLE
ci: preview workflowをアプリ関連変更のみで起動するよう制限

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,13 @@ name: preview
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'apps/sandbox/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'package.json'
+      - '.github/workflows/preview.yml'
+      - '.github/actions/**'
 
 jobs:
   update:


### PR DESCRIPTION
## 概要

PR の `preview` ワークフロー（EAS Update 配信）を、アプリケーション関連ファイルが変更された場合のみ起動するように制限する。

## 背景・動機

現状は全ての PR で EAS Update が配信されており、ドキュメントや CI 設定のみの変更など JS バンドルに影響しない変更でも OTA 配信が走っていた。EAS Update は JS バンドル + アセットを配信する仕組みなので、それらに関係ない変更では実行する意味がなく、Expo の無料枠や実行時間の無駄になっていた。

## アプローチ

`pull_request` トリガーに `paths` フィルターを追加する。

- **ワークフローレベルで適用**: `update` と `delete-branch` 両方のジョブを同じ条件で絞る。非対象 PR では EAS branch 自体が作成されないため、クローズ時の削除も不要というモデル。
- **大雑把な粒度**: 最初は個別ファイル列挙案（`app.json`, `babel.config.js`, `metro.config.js` など）を検討したが、「もう少し大雑把に指定したい」とのフィードバックを受けてディレクトリ単位に変更。`apps/sandbox/android/**`, `ios/**`, `docs/**` など厳密には EAS Update に無関係なパスも含むが、メンテ負担を下げるため敢えて除外していない。
- **含めるパス**: `apps/sandbox/**`, ルートの `pnpm-lock.yaml` / `pnpm-workspace.yaml` / `package.json`, `.github/workflows/preview.yml` 自身, `.github/actions/**`

## レビューポイント

- `paths` に含めたディレクトリ・ファイルの範囲が適切か（過不足ないか）
- ワークフロー自身（`preview.yml`）を `paths` に含めることで、今後このワークフローを修正する PR でも動作確認できる想定