### PR TITLE
ci: Dependabot PRではpreview workflowをスキップ

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   update:
     name: EAS Update
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,7 +40,7 @@ jobs:
 
   delete-branch:
     name: Delete EAS Update Branch
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## 概要

Dependabotが作成したPRでは `.github/workflows/preview.yml` のEAS Update配信ジョブをスキップするように変更。

## 背景・動機

`preview.yml` のpaths filterには `.github/actions/**` が含まれているため、Dependabotが `.github/actions/*` のGitHub Actions更新PRを作成するとEAS Updateが起動してしまう。アプリの動作確認が不要なDependabot PRではEAS Updateリソースとワークフロー実行時間を無駄に消費するため、スキップしたい。

## アプローチ

`update` と `delete-branch` の両ジョブの `if` 条件に `github.event.pull_request.user.login != 'dependabot[bot]'` を追加。

- `update`: 既存の `github.event.action != 'closed'` に条件を追加
- `delete-branch`: Dependabot PRではEASブランチが作成されていないため、クローズ時の `eas branch:delete` は失敗する。よってスキップが妥当

### `github.actor` ではなく `github.event.pull_request.user.login` を使う理由

`github.actor` はワークフロー起動者を指すため、re-run時などに挙動が変わる可能性がある。PR作成者を厳密に判定するため `github.event.pull_request.user.login` を採用した。

## レビューポイント

- Dependabot以外のbot（例: renovate等）を今後追加する予定がある場合は、より汎用的な条件に変更する余地あり。現状はDependabotのみ利用しているためハードコードで対応した