### PR TITLE
ci: eas-cli インストールを pnpm から npm に切り替え

### DIFF
--- a/.github/actions/setup-eas/action.yml
+++ b/.github/actions/setup-eas/action.yml
@@ -21,5 +21,5 @@ runs:
       with:
         eas-version: latest
         token: ${{ inputs.token }}
-        packager: pnpm
+        packager: npm
         eas-cache: false


### PR DESCRIPTION
## 概要

`main` ブランチで失敗している `eas-update` / `eas-build` ワークフローを修復する。`setup-eas/action.yml` 内の `expo/expo-github-action@v8` の `packager` 入力を `pnpm` から `npm` に変更し、eas-cli の一時インストール経路だけを npm 経由に切り替える。プロジェクト依存解決 (`pnpm install --frozen-lockfile`) は従来通り pnpm 10.33.0 のまま。

## 背景・動機

### 症状

`main` への push でトリガされる `eas-update` (run 24984345503) と `eas-build` (run 24984345511) が以下のエラーで失敗していた:

```
ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: dtrace-provider@0.8.8
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

`Setup EAS` ステップ中で `pnpm add eas-cli@<version>` が exit 1。`CI` (lint/typecheck) は成功しており、影響は EAS 系ワークフローに限定されていた。

### 失敗の起点

最後の成功 (PR #95, 2026-04-20 08:10) と最初の失敗 (PR #93, 2026-04-20 08:33) の間の唯一の差分は dependabot による `pnpm/action-setup` の v5 → v6 アップデート (`.github/actions/setup-node/action.yml`)。

### 根本原因

`pnpm/action-setup` の v5 と v6 で、ブートストラップ pnpm とターゲット pnpm のインストール構造が変わったことに起因する:

**v5** (これまで動いていた構造)
- 同梱の pnpm 8.x で `pnpm install <target> --no-lockfile` を実行
- `~/setup-pnpm/node_modules/pnpm/` に **ターゲット版 (10.33.0)** が直接入り、`.bin/pnpm` symlink もそれを指す

**v6** (壊れた構造)
- `npm ci` でブートストラップ **pnpm 11-rc** を `~/setup-pnpm/node_modules/pnpm/` にインストール (失敗ログの `pnpm store path` が `store/v11` を返すことで確認)
- 続けて `bootstrap_pnpm self-update <target>` を実行するが、pnpm 11 仕様で self-update された binary は `PNPM_HOME/bin/` 配下に置かれる ([pnpm 11 release notes](https://github.com/pnpm/pnpm/releases/tag/v11.0.0-rc.0): _Globally installed binaries are now stored in a `bin` subdirectory of `PNPM_HOME`_)
- 結果、`~/setup-pnpm/node_modules/.bin/pnpm` の symlink は **ブートストラップ pnpm 11-rc を指したまま**
- プロジェクトの `pnpm install --frozen-lockfile` は CWD `/workspace` で `packageManager: pnpm@10.33.0` を尊重し 10.33.0 として動作 ("Done in 6.7s using pnpm v10.33.0") → ignored builds は warning で済む
- 一方 `expo/expo-github-action@v8` は `[command]/home/runner/setup-pnpm/node_modules/.bin/pnpm add eas-cli@18.8.1` を CWD `~/setup-pnpm/` (`packageManager` 無し) で叩くため、symlink 先の pnpm 11-rc として動作する
- pnpm 11(-rc) は `strictDepBuilds: true` がデフォルト (release notes 明記) → `dtrace-provider@0.8.8` (Solaris 専用ネイティブモジュール) のビルドスクリプト無視がエラー化される

v6 の binary 配置は pnpm 11 の意図した設計なので、pnpm 11 GA 後も同じ挙動になる。`expo/expo-github-action@v8` 自体も 2024 年から更新されておらず upstream 修正は期待しづらい。

## アプローチ

### 採用した方針

`expo/expo-github-action@v8` の `packager: pnpm` → `packager: npm` への 1 行変更:

```yaml
- name: Setup EAS
  uses: expo/expo-github-action@v8
  with:
    eas-version: latest
    token: ${{ inputs.token }}
    packager: npm           # 変更箇所
    eas-cache: false
```

採用理由:

- npm には pnpm 11 の `strictDepBuilds` 相当のゲートが無く、`dtrace-provider` の native build 失敗 (Solaris 専用なので Linux runner で実害無し) に引っかからない
- eas-cli は CI で一時起動する CLI ツールであり、`packageManager` で固定する必然性が無い → npm の global install が用途として自然
- npm はランナーに pre-installed (`npm: 11.11.0` がログで確認可能)
- `pnpm/action-setup@v6` の内部レイアウトに依存しないため、v6 の今後の patch でも壊れにくい

### 検討して却下した代替案

会話の中で複数の方針を検討したが、以下の理由で本案に収束した:

- **`pnpm/action-setup` を v5 にピン留め**: v6 維持の前提で却下
- **env 変数 `pnpm_config_strict_dep_builds=false` を `expo/expo-github-action@v8` に渡す**: 対症療法。pnpm 11 が今後追加する別の strict デフォルトに都度反応する必要がある
- **`~/setup-pnpm/node_modules/pnpm` をプロジェクト pnpm で上書き install するステップを `setup-eas` に追加**: 動くが、`pnpm/action-setup@v6` の内部レイアウト (dest の場所、symlink ターゲットが `pnpm.cjs` か `pnpm.mjs` か等) に依存するハック
- **`expo/expo-github-action@v8` を捨てて `pnpm dlx eas-cli` で直接実行**: 抜本的だが `preview.yml` の `expo/expo-github-action/preview@v8` (PR コメント投稿) まで再実装が必要で影響範囲が広い

### 影響範囲の確認

- メインの `pnpm install --frozen-lockfile` (プロジェクト依存解決) は引き続き pnpm 10.33.0 で動作。今回の変更は eas-cli の install 経路のみに影響
- `eas-cache: false` で eas-cli キャッシュは元から無効。packager 変更によるキャッシュ挙動の差は無い
- `preview.yml` の `expo/expo-github-action/preview@v8` (コメント投稿等) は eas-cli のバイナリを PATH 経由で呼ぶだけなので、npm の global install で配置された `eas` も問題なく見つかる

## 検証結果

PR の preview ワークフロー (run 25043589977) で以下を確認済み:

- `Setup EAS` ステップが exit 0 で成功 (修正前は `ERR_PNPM_IGNORED_BUILDS`)
- ログに `Installing eas-cli (18.8.1) with npm` が出力され、packager 変更が反映されていることを確認
- `Create preview` ステップで PR にプレビューコメントが投稿される動作 (`expo/expo-github-action/preview@v8`) が壊れていないことを確認

マージ後は `main` への push でトリガされる `eas-update` / `eas-build` が両方成功することを最終確認する。

## レビューポイント

- `packager: npm` への切り替えで `eas-cache: false` の挙動が変わらないか (action ソース上は packager 別に分岐していないが、念のため確認したい)
- 将来 `pnpm/action-setup@v6` の内部実装が変わって元の構造に戻った場合でも、本変更は `npm` でのインストールを継続するため特に追従不要、という認識でよいか

🤖 Generated with [Claude Code](https://claude.com/claude-code)