### PR TITLE
build: pnpm-workspace.yamlからtrustPolicy: no-downgradeを削除

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,3 @@ nodeLinker: hoisted
 minimumReleaseAge: 1440
 # 直接依存（package.jsonに記載されている依存）以外はGitリポジトリ、tarball URLを参照することをブロック
 blockExoticSubdeps: true
-# lockfileに記載されたパッケージの信頼レベルが以前のリリースより低下した場合にインストールを拒否
-trustPolicy: no-downgrade
-trustPolicyExclude:
-  - 'react-native-worklets@0.7.2'


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` から `trustPolicy: no-downgrade` と関連する `trustPolicyExclude` を削除する。`trustPolicyExclude` は `trustPolicy` の存在が前提の例外リストのため、合わせて削除している。

## 背景・動機

pnpm の `trustPolicy` はサプライチェーン攻撃対策として有用だが、信頼レベルの判定が **publish 日時順** で行われるため、以下のような誤検知が発生していた:

- **react-native-worklets** ([#91](https://github.com/yami-beta/expo-sandbox/pull/91)): nightly ビルドは GitHub Actions (Trusted Publisher + Provenance) で公開される一方、安定版は手動公開で Provenance なし。リリースフローの違いが downgrade と判定された。
- **semver** ([#96](https://github.com/yami-beta/expo-sandbox/pull/96)): `semver@7.5.1` (provenance 付き) の後にメンテナンスリリースされた `semver@6.3.1` (provenance なし) が downgrade と判定され、`pnpm dedupe` がブロックされた。

これらは pnpm 側で既知の課題:

- [pnpm/pnpm#10329](https://github.com/pnpm/pnpm/issues/10329) - Dedupe fails with trustPolicy `no-downgrade`
- [pnpm/pnpm#10202](https://github.com/pnpm/pnpm/issues/10202) - `no-downgrade` should check the same major version

メジャーバージョン保守ブランチや手動／自動リリース併用パッケージで頻繁に引っかかり、運用コストが防御効果に見合わないため一旦外す方針とした。

## アプローチ

`pnpm-workspace.yaml` から該当 4 行（コメント含む）を削除。

なお `minimumReleaseAge: 1440` と `blockExoticSubdeps: true` は引き続き有効に残す（publish 日時順比較の問題には該当しない、コストの低い防御策のため）。

## 動作確認

- [x] `pnpm install` 正常完了、`pnpm-lock.yaml` に差分なし
- [x] `pnpm dedupe --check` が trustPolicy 関連エラーなしで通る ([#96](https://github.com/yami-beta/expo-sandbox/pull/96) で発生していた問題が解消)