### PR TITLE
feat: Themedコンポーネントとデザイントークンを導入

### DIFF
--- a/apps/sandbox/src/components/link-list/LinkList.tsx
+++ b/apps/sandbox/src/components/link-list/LinkList.tsx
@@ -1,8 +1,9 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Link, type LinkProps } from "expo-router";
 import type { ReactElement, ReactNode } from "react";
-import { FlatList, Pressable, StyleSheet, Text } from "react-native";
-import { useThemeContext } from "../../theme/ThemeContext";
+import { FlatList, Pressable, StyleSheet } from "react-native";
+import { useTheme } from "../../theme/useTheme";
+import { ThemedText } from "../themed-text/ThemedText";
 
 export type LinkItem = {
   href: LinkProps["href"];
@@ -14,7 +15,7 @@ type LinkListProps = {
 };
 
 export function LinkList({ data }: LinkListProps): ReactElement {
-  const { theme } = useThemeContext();
+  const colors = useTheme();
 
   return (
     <FlatList
@@ -22,19 +23,19 @@ export function LinkList({ data }: LinkListProps): ReactElement {
       renderItem={({ item }) => <LinkListItem {...item} />}
       keyExtractor={(item) => (typeof item.href === "string" ? item.href : item.href.pathname)}
       contentContainerStyle={styles.container}
-      style={{ backgroundColor: theme.colors.background }}
+      style={{ backgroundColor: colors.background }}
     />
   );
 }
 
 function LinkListItem({ href, text }: LinkItem): ReactElement {
-  const { theme } = useThemeContext();
+  const colors = useTheme();
 
   return (
     <Link href={href} asChild>
       <Pressable style={styles.item}>
-        <Text style={[styles.itemText, { color: theme.colors.text }]}>{text}</Text>
-        <Ionicons name="chevron-forward" size={20} color={theme.colors.text} />
+        <ThemedText type="subtitle">{text}</ThemedText>
+        <Ionicons name="chevron-forward" size={20} color={colors.text} />
       </Pressable>
     </Link>
   );
@@ -49,8 +50,5 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     padding: 16,
-  },
-  itemText: {
-    fontSize: 20,
   },
 });

--- a/apps/sandbox/src/components/themed-text/ThemedText.tsx
+++ b/apps/sandbox/src/components/themed-text/ThemedText.tsx
@@ -1,0 +1,69 @@
+import type { ReactElement } from "react";
+import { StyleSheet, Text, type TextProps, type TextStyle } from "react-native";
+import { Fonts, type ColorTokenName } from "../../constants/theme";
+import { useTheme } from "../../theme/useTheme";
+
+export type ThemedTextType =
+  | "default"
+  | "title"
+  | "subtitle"
+  | "small"
+  | "smallBold"
+  | "link"
+  | "linkPrimary"
+  | "code";
+
+export interface ThemedTextProps extends TextProps {
+  type?: ThemedTextType;
+  themeColor?: ColorTokenName;
+}
+
+const typeStyles: Record<ThemedTextType, TextStyle> = StyleSheet.create({
+  default: {
+    fontSize: 16,
+    fontWeight: "400",
+    lineHeight: 24,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: "700",
+    lineHeight: 32,
+  },
+  subtitle: {
+    fontSize: 20,
+    fontWeight: "600",
+  },
+  small: {
+    fontSize: 14,
+    fontWeight: "400",
+  },
+  smallBold: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  link: {
+    fontSize: 16,
+    fontWeight: "400",
+    textDecorationLine: "underline",
+  },
+  linkPrimary: {
+    fontSize: 16,
+    fontWeight: "600",
+    textDecorationLine: "underline",
+  },
+  code: {
+    fontSize: 14,
+    fontWeight: "400",
+    fontFamily: Fonts.mono,
+  },
+});
+
+export function ThemedText({
+  type = "default",
+  themeColor = "text",
+  style,
+  ...rest
+}: ThemedTextProps): ReactElement {
+  const colors = useTheme();
+  return <Text style={[{ color: colors[themeColor] }, typeStyles[type], style]} {...rest} />;
+}

--- a/apps/sandbox/src/components/themed-view/ThemedView.tsx
+++ b/apps/sandbox/src/components/themed-view/ThemedView.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from "react";
+import { View, type ViewProps } from "react-native";
+import type { ColorTokenName } from "../../constants/theme";
+import { useTheme } from "../../theme/useTheme";
+
+export interface ThemedViewProps extends ViewProps {
+  type?: ColorTokenName;
+}
+
+export function ThemedView({ type = "background", style, ...rest }: ThemedViewProps): ReactElement {
+  const colors = useTheme();
+  return <View style={[{ backgroundColor: colors[type] }, style]} {...rest} />;
+}

--- a/apps/sandbox/src/constants/theme.ts
+++ b/apps/sandbox/src/constants/theme.ts
@@ -1,0 +1,62 @@
+import { Platform } from "react-native";
+
+export const Colors = {
+  light: {
+    text: "#000000",
+    textSecondary: "#60646C",
+    background: "#ffffff",
+    backgroundElement: "#F0F0F3",
+    backgroundSelected: "#E0E1E6",
+  },
+  dark: {
+    text: "#ffffff",
+    textSecondary: "#B0B4BA",
+    background: "#000000",
+    backgroundElement: "#212225",
+    backgroundSelected: "#2E3135",
+  },
+} as const;
+
+export type ColorScheme = keyof typeof Colors;
+export type ColorTokenName = keyof (typeof Colors)["light"];
+export type ColorTokens = Readonly<Record<ColorTokenName, string>>;
+
+export const Spacing = {
+  half: 2,
+  one: 4,
+  two: 8,
+  three: 16,
+  four: 24,
+  five: 32,
+  six: 64,
+} as const;
+
+export type SpacingName = keyof typeof Spacing;
+
+interface FontFamily {
+  sans: string;
+  serif: string;
+  rounded: string;
+  mono: string;
+}
+
+export const Fonts: FontFamily = Platform.select({
+  ios: {
+    sans: "system-ui",
+    serif: "ui-serif",
+    rounded: "ui-rounded",
+    mono: "ui-monospace",
+  },
+  android: {
+    sans: "normal",
+    serif: "serif",
+    rounded: "normal",
+    mono: "monospace",
+  },
+  default: {
+    sans: "normal",
+    serif: "serif",
+    rounded: "normal",
+    mono: "monospace",
+  },
+});

--- a/apps/sandbox/src/theme/ThemeContext.tsx
+++ b/apps/sandbox/src/theme/ThemeContext.tsx
@@ -7,6 +7,7 @@ import {
   type Theme,
 } from "@react-navigation/native";
 import Storage from "expo-sqlite/kv-store";
+import { Colors, type ColorScheme, type ColorTokens } from "../constants/theme";
 
 export type ThemeMode = "system" | "light" | "dark";
 
@@ -19,6 +20,8 @@ interface ThemeContextValue {
   setMode: (mode: ThemeMode) => void;
   theme: Theme;
   isDark: boolean;
+  scheme: ColorScheme;
+  colors: ColorTokens;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -45,6 +48,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     return isDark ? NavigationDarkTheme : NavigationDefaultTheme;
   }, [isDark]);
 
+  const scheme: ColorScheme = isDark ? "dark" : "light";
+  const colors = Colors[scheme];
+
   const handleSetMode = (newMode: ThemeMode) => {
     setMode(newMode);
     Storage.setItemSync(STORAGE_KEY.THEME_MODE, newMode);
@@ -56,8 +62,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setMode: handleSetMode,
       theme,
       isDark,
+      scheme,
+      colors,
     }),
-    [mode, theme, isDark],
+    [mode, theme, isDark, scheme, colors],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/apps/sandbox/src/theme/useTheme.ts
+++ b/apps/sandbox/src/theme/useTheme.ts
@@ -1,0 +1,6 @@
+import type { ColorTokens } from "../constants/theme";
+import { useThemeContext } from "./ThemeContext";
+
+export function useTheme(): ColorTokens {
+  return useThemeContext().colors;
+}

--- a/tasks/theme-context-consolidation.md
+++ b/tasks/theme-context-consolidation.md
@@ -1,0 +1,69 @@
+# ThemeContext の値の整理（mode / theme / scheme / colors の重複解消）
+
+## ステータス
+
+- 状態: Backlog
+- 着手予定: NativeTabs 移行（別タスク）の完了後
+- 起票元 PR: #101 (`feat: Themedコンポーネントとデザイントークンを導入`)
+- 起票日: 2026-05-07
+
+## 背景
+
+PR #101 で `ThemeContextValue` に `scheme: ColorScheme` と `colors: ColorTokens` を追加した結果、Context が公開する値が以下の 6 つになった。
+
+```ts
+interface ThemeContextValue {
+  mode: ThemeMode;                  // "system" | "light" | "dark" — ユーザー設定値（永続化対象）
+  setMode: (mode: ThemeMode) => void;
+  theme: Theme;                     // @react-navigation の Theme — タブバー / ヘッダー等で使用
+  isDark: boolean;                  // mode を解決した bool
+  scheme: ColorScheme;              // "light" | "dark" — isDark の文字列版（新規）
+  colors: ColorTokens;              // Colors[scheme] — 画面内 Themed* で使用（新規）
+}
+```
+
+これらは「ユーザー設定（`mode` / `setMode`）」と「設定の解決結果（`theme` / `isDark` / `scheme` / `colors`）」に大別できるが、**解決結果側に重複がある**。
+
+| 値 | 派生元 | 用途 | 重複先 |
+|---|---|---|---|
+| `isDark` | `mode` + `colorScheme` | 単純な真偽値判定 | `scheme === "dark"` で代用可 |
+| `scheme` | 同上 | `Colors[scheme]` の引数 | `isDark` から導出可 |
+| `theme` | `isDark` | @react-navigation 系コンポーネントに渡す | `colors` と起点が同じ |
+| `colors` | `scheme` | Themed* / 画面内 UI に使う | `theme.colors` と一部キーが対応 |
+
+## なぜ今すぐ整理しないか
+
+- `theme: Theme` の主な利用箇所は `(tabs)/_layout.tsx` の `screenOptions` など **`@react-navigation/bottom-tabs` 経由のタブバー周り**
+- これは別タスク「NativeTabs (`expo-router/unstable-native-tabs`) への移行」（auto memory `project_native_tabs_migration.md` 参照）で大きく書き換わる予定
+- NativeTabs は `theme: Theme` を直接受け取らず、`backgroundColor` / `tintColor` / `iconColor` などを個別 prop で受ける形なので、`theme` の必要性自体が変わる
+- 先に整理すると NativeTabs 移行で再度書き換えが発生して二度手間になる
+
+## 着手時に検討する整理案
+
+### 案 A: `isDark` を撤去し `scheme` に統一
+
+- `isDark` を消し、利用箇所を `scheme === "dark"` に置換
+- 冗長性は減るが、boolean を使いたい場面では条件式が冗長になるので慎重に判断
+
+### 案 B: `theme` を Context から外し、必要箇所で `colors` から導出
+
+- NativeTabs 移行後、`theme: Theme` を必要とするのは `Stack`/`Drawer` などのナビゲーターの `screenOptions` のみになる想定
+- `colors` から `Theme` を組み立てるヘルパー（例: `buildNavigationTheme(colors)`）を作り、利用箇所でローカルに作る or root layout で渡す
+- ThemeContext は「ユーザー設定の永続化」と「解決済みカラートークン」に責務を絞れる
+
+### 案 C: 全部残すが、内部実装の重複だけ消す
+
+- 公開 API は変えず、内部で `scheme = isDark ? "dark" : "light"` のような計算を明示的に DRY に
+- 影響最小、効果も小
+
+## 着手時の前提条件
+
+- NativeTabs 移行 PR がマージ済み
+- 全 Themed* 移行（navigation-patterns/* 含む）がある程度進んでおり、`colors` ベースの参照が中心になっている
+
+## 関連
+
+- PR #101: https://github.com/yami-beta/expo-sandbox/pull/101
+- 該当ファイル: `apps/sandbox/src/theme/ThemeContext.tsx`
+- 関連メモリ: `project_native_tabs_migration.md`（auto memory ディレクトリ）
+- 関連 plan: `/Users/takahiro.abe/.claude/plans/expo-55-https-expo-dev-changelog-sdk-55-ticklish-ritchie.md`


### PR DESCRIPTION
## 概要

Expo SDK 55 新デフォルトテンプレートの「Refreshed design for a better out-of-the-box experience」の実装詳細にあたる **Themed コンポーネント (`ThemedText` / `ThemedView`) とデザイントークン (`Colors` / `Spacing` / `Fonts`)** を本リポに導入する。`LinkList` を最初の適用例として置換した。

加えて、後続タスクの引き継ぎ資料を置く `tasks/` ディレクトリを新設し、最初のタスクとして `tasks/theme-context-consolidation.md` を追加した（`ThemeContextValue` の `mode / theme / scheme / colors / isDark` の重複整理を NativeTabs 移行後に行う計画）。

## 背景・動機

[Expo SDK 55 changelog](https://expo.dev/changelog/sdk-55) で明示されたテンプレート刷新のうち、

- Native Tabs API → 別セッションで進行（`unstable` API のため判断材料の収集が必要）
- フォルダ構造 `/app` → `/src/app` → 既存対応済み
- **Refreshed design** → **本 PR で対応**

新テンプレートのリポジトリ（`expo/expo` の `sdk-55` ブランチ）では、`src/components/themed-text.tsx` `themed-view.tsx`、`src/constants/theme.ts`、`src/hooks/use-theme.ts` が標準で含まれている。これらを既存アプリに取り込むことで、画面内のテキスト・ビューのカラー/タイポグラフィの一貫性とテーマ切替への追従を共通基盤化する。

## アプローチ

### 既存 ThemeContext との統合方針

既存の `ThemeContext`（`mode: system/light/dark` を `expo-sqlite/kv-store` で永続化）を **真実源** として保つため、新たに `colors: ColorTokens` と `scheme: ColorScheme` を Context 値に追加する形で拡張した。`Themed*` コンポーネントは内部で `useTheme()` ファサード hook を介して色を取得するため、永続化された mode に追従する。

検討した代替案:

- **`useColorScheme()` を直接使う新テンプレ完コピー案**: 既存の `mode` 永続化を無視してシステム設定優先の動作になる重大な後退になるため不採用
- **`useThemeColors()` を独立 hook として切る案**: hook 階層が増えて認知負荷が高いため不採用

`@react-navigation` の `theme`（タブバー・ヘッダー・ボーダーで使用中）はそのまま残し、画面内コンテンツ用の新トークンと **2 層分離で共存** させる。

### 型設計

- `Colors` は light/dark 同形のオブジェクトリテラル + `as const`
- 当初 `ColorTokens = (typeof Colors)["light"]` で定義したが、`Colors[scheme]` の代入時にリテラル型ユニオン同士の互換が成立せず TS2322 エラーが出たため、`Readonly<Record<ColorTokenName, string>>` に緩めた（プロジェクト規約により Type Assertion は不可）
- `Platform.select` は `default` キー付きで呼び出して `T | undefined` を回避（`exactOptionalPropertyTypes` 対応）

### スコープ判断

- 適用対象は `LinkList` のみ。`navigation-patterns/*` の 4 画面は StyleSheet が大きく `<Trans>` を多用するため、後続 PR で段階移行する
- `(tabs)/settings/theme.tsx` のラベル化は今回見送り（任意項目だったため）
- `ThemeContextValue` には `mode / theme / scheme / colors / isDark` と用途が一部重複する値が並ぶが、`theme: Theme` の主要利用箇所が NativeTabs 移行で大きく変わる予定のため、整理は **NativeTabs 移行後に後続タスクとして実施**（詳細は `tasks/theme-context-consolidation.md`）

## レビューポイント

- **`LinkList` の視覚変化**: リスト項目テキストの `fontWeight` が `400 → 600` に変わる（`subtitle` バリアント `20/600` に統合）。リスト項目タイトルとしてのセマンティックを優先した意図的な変更。問題があれば `default` バリアント + 明示 `fontSize` への差し戻しが可能
- **タイポグラフィ初期値**: 新テンプレート踏襲（title 32/700、subtitle 20/600、default 16/400 など）。本リポのデザイン要件に合わない場合は調整したい
- **`Spacing` / `Fonts.mono` などの未使用トークン**: 今 PR では参照していないが、将来の段階移行を見越して新テンプレと同じ形で先に導入している
- **`tasks/` ディレクトリの新設**: `docs/`（長期参照する説明資料）とは役割を分け、`tasks/` には完了後に削除/アーカイブする短期的な作業メモを置く運用を想定
- **NativeTabs (要素B)** は別 PR で進行予定

## 動作確認

- [x] `pnpm -r run lint` 通過
- [x] `pnpm -r run typecheck` 通過
- [x] `pnpm -r run lingui:extract` で po に diff なし
- [ ] iOS dev build で system / light / dark の3モード切替を確認
- [ ] Android dev build で同上
- [ ] Web で同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)