### PR TITLE
feat: タブを expo-router/unstable-native-tabs に移行

### DIFF
--- a/apps/sandbox/src/app/(tabs)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/_layout.tsx
@@ -1,43 +1,34 @@
-import { FontAwesome } from "@expo/vector-icons";
-import { Tabs } from "expo-router";
-import { useThemeContext } from "../../theme/ThemeContext";
+import { NativeTabs } from "expo-router/unstable-native-tabs";
 import { useLingui } from "@lingui/react/macro";
+import { useThemeContext } from "../../theme/ThemeContext";
 
 export default function TabLayout() {
-  const { theme } = useThemeContext();
+  const { colors } = useThemeContext();
   const { t } = useLingui();
 
   return (
-    <Tabs
-      screenOptions={{
-        tabBarStyle: {
-          backgroundColor: theme.colors.card,
-          borderTopColor: theme.colors.border,
-        },
-        tabBarActiveTintColor: theme.colors.primary,
-        tabBarInactiveTintColor: theme.colors.text,
-        headerStyle: {
-          backgroundColor: theme.colors.card,
-        },
-        headerTintColor: theme.colors.text,
-        headerShadowVisible: !theme.dark,
+    <NativeTabs
+      backgroundColor={colors.background}
+      tintColor={colors.text}
+      iconColor={{ default: colors.textSecondary, selected: colors.text }}
+      labelStyle={{
+        default: { color: colors.textSecondary },
+        selected: { color: colors.text, fontWeight: "600" },
       }}
+      indicatorColor={colors.backgroundElement}
     >
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: t`ホーム`,
-          tabBarIcon: ({ color }) => <FontAwesome size={28} name="home" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          title: t`設定`,
-          headerShown: false,
-          tabBarIcon: ({ color }) => <FontAwesome size={28} name="cog" color={color} />,
-        }}
-      />
-    </Tabs>
+      <NativeTabs.Trigger name="index">
+        <NativeTabs.Trigger.Icon sf={{ default: "house", selected: "house.fill" }} md="home" />
+        <NativeTabs.Trigger.Label>{t`ホーム`}</NativeTabs.Trigger.Label>
+      </NativeTabs.Trigger>
+
+      <NativeTabs.Trigger name="settings">
+        <NativeTabs.Trigger.Icon
+          sf={{ default: "gearshape", selected: "gearshape.fill" }}
+          md="settings"
+        />
+        <NativeTabs.Trigger.Label>{t`設定`}</NativeTabs.Trigger.Label>
+      </NativeTabs.Trigger>
+    </NativeTabs>
   );
 }

--- a/apps/sandbox/src/app/(tabs)/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import { SafeAreaView } from "react-native-screens/experimental";
 import { LinkList, type LinkItem } from "../../components/link-list/LinkList";
 
 export default function Index() {
@@ -9,5 +10,9 @@ export default function Index() {
     },
   ] as const satisfies LinkItem[];
 
-  return <LinkList data={list} />;
+  return (
+    <SafeAreaView edges={{ top: true }}>
+      <LinkList data={list} />
+    </SafeAreaView>
+  );
 }

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -107,7 +107,7 @@ msgid "デモコンテンツ"
 msgstr "Demo Content"
 
 #: src/app/_layout.tsx:42
-#: src/app/(tabs)/index.tsx:8
+#: src/app/(tabs)/index.tsx:9
 msgid "ナビゲーションパターン"
 msgstr "Navigation Patterns"
 

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -145,7 +145,7 @@ msgid "フォームを送信"
 msgstr "Submit Form"
 
 #: src/app/_layout.tsx:38
-#: src/app/(tabs)/_layout.tsx:29
+#: src/app/(tabs)/_layout.tsx:22
 msgid "ホーム"
 msgstr "Home"
 
@@ -219,7 +219,7 @@ msgstr "Enter name"
 msgid "完了"
 msgstr "Done"
 
-#: src/app/(tabs)/_layout.tsx:36
+#: src/app/(tabs)/_layout.tsx:30
 #: src/app/(tabs)/settings/_layout.tsx:19
 msgid "設定"
 msgstr "Settings"

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -107,7 +107,7 @@ msgid "デモコンテンツ"
 msgstr "デモコンテンツ"
 
 #: src/app/_layout.tsx:42
-#: src/app/(tabs)/index.tsx:8
+#: src/app/(tabs)/index.tsx:9
 msgid "ナビゲーションパターン"
 msgstr "ナビゲーションパターン"
 

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -145,7 +145,7 @@ msgid "フォームを送信"
 msgstr "フォームを送信"
 
 #: src/app/_layout.tsx:38
-#: src/app/(tabs)/_layout.tsx:29
+#: src/app/(tabs)/_layout.tsx:22
 msgid "ホーム"
 msgstr "ホーム"
 
@@ -219,7 +219,7 @@ msgstr "名前を入力"
 msgid "完了"
 msgstr "完了"
 
-#: src/app/(tabs)/_layout.tsx:36
+#: src/app/(tabs)/_layout.tsx:30
 #: src/app/(tabs)/settings/_layout.tsx:19
 msgid "設定"
 msgstr "設定"


### PR DESCRIPTION
## 概要

`(tabs)/_layout.tsx` の `Tabs`（@react-navigation/bottom-tabs）を Expo SDK 55 で正式提供された試験 API `expo-router/unstable-native-tabs` の `NativeTabs` に移行し、iOS では Liquid Glass のタブバー、Android では Material Symbol によるネイティブ準拠のタブ UI を得る。新規ネイティブ依存の追加なし。

## 背景・動機

Expo SDK 55 へのアップグレード（#100）と Themed コンポーネント / `Colors` トークン整備（#101）の延長で、SDK 55 新テンプレートが採用した NativeTabs を sandbox にも取り込む。狙いは以下:

- iOS の Liquid Glass / SF Symbol によるネイティブな質感
- Android の Material Symbol による標準準拠の見た目
- ネイティブのタブ切替アニメーション
- 先行 PR の `Colors` トークンを活かしたテーマ連動の簡素化（`useThemeContext().colors` を `NativeTabs` の各 prop に直接渡す）

`expo-symbols` / `react-native-screens` は SDK 55 で既導入のため、依存追加・`prebuild --clean` ともに不要。

## アプローチ

### ナビゲーションスタック構造

公式の最小例は `app/_layout.tsx` 直下に `NativeTabs` を置く形だが、本プロジェクトのルート `Stack` には `navigation-patterns/*` の modal / formSheet 画面が `(tabs)` と並列登録されており、これらをタブの上に被せる前提になっている。そのためルート `Stack` はそのまま維持し、`(tabs)/_layout.tsx` の中身だけを差し替えた。

```
RootStack (app/_layout.tsx)              ← 変更なし
├── (tabs) Stack.Screen [headerShown:false]
│   └── NativeTabs (ネイティブタブバーのみ、ヘッダーUI無し)  ← 差し替え
│       ├── index    (= (tabs)/index.tsx)
│       └── settings
│           └── 内側 Stack (= settings/_layout.tsx)  ← 既存維持
│               ├── index    ← ヘッダー「設定」
│               └── theme    ← ヘッダー「テーマ」
└── navigation-patterns/* (modal / formSheet)        ← 変更なし
```

### ヘッダー方針

NativeTabs はヘッダー UI を持たない（公式: *"The JavaScript `<Tabs />` have a mock stack header which is not present in the native tabs."*）。本 PR では:

- **Home タブ**: ヘッダー無し（NativeTabs 直下に画面を配置）
- **Settings タブ**: 既存の内側 Stack を維持してヘッダー「設定」「テーマ」を継続表示

検討した代替案:

- Home にも `(home)` ルートグループ + 内側 Stack を追加してヘッダーを付ける案 → 「Home はヘッダー無しでよい」という方針判断のため不採用（Settings との非対称は許容）
- 全タブをヘッダー無しに統一する案 → Settings → Theme の階層 UI が失われるため不採用

### Android のステータスバー対策（修正コミット `abb91da`）

ヘッダー無しの Home タブで Android のステータスバーにコンテンツが食い込む不具合を実機確認で発見。型定義 `disableAutomaticContentInsets` の説明にあるとおり、Android では NativeTabs の自動 SafeAreaView ラップが bottom inset しか適用しない仕様のため top が未対処になっていた。

`react-native-screens/experimental` の `SafeAreaView` で top inset のみ確保（bottom は NativeTabs の自動 SafeArea に任せ、二重 padding を回避）。

`react-native-safe-area-context` ではなく `react-native-screens/experimental` を採用した理由:

- NativeTabs（react-native-screens の Native Bottom Tabs）と同じネイティブモジュールから safe area を取得 → Screen のフレーム座標系と完全に同期
- 公式型定義の `disableAutomaticContentInsets` 説明でも `react-native-screens/experimental` の SafeAreaView が推奨されている
- `flex: 1` がデフォルトなのでスタイル定義が不要
- NativeTabs（unstable）採用と同程度のリスク許容として整合

`react-native-safe-area-context` 自体は他画面（form-sheet-screen.tsx）で利用継続。

### Web 対応

unstable API のため、Web は expo-router 内蔵のフォールバックに任せる試験的扱い。問題が出た場合は後続コミットで `(tabs)/_layout.web.tsx` を追加し旧 `Tabs` 実装を残す保険策で対応する方針。

## レビューポイント

- ルート `Stack` を維持して `(tabs)/_layout.tsx` のみ差し替える構造の妥当性
- Home（ヘッダー無し）と Settings（ヘッダーあり）の見た目の非対称が許容可能か
- `react-native-screens/experimental`（experimental API）への依存追加の是非。`react-native-screens` の minor バージョンで破壊的変更があり得る点は許容前提
- 実機確認観点:
  - **iOS**: Liquid Glass のタブバー、SF Symbol（house/gearshape）の選択時 fill 切替、ライト/ダーク追従、Home → modal/formSheet 遷移
  - **Android**: Material Symbol（home/settings）、`indicatorColor` の選択中インジケータ、Home でのステータスバー食い込み無し
  - **Web**: タブが押下でき画面が切り替わる（アイコン非表示は試験扱い）

## 検証

```bash
pnpm -r run lint        # ✅
pnpm -r run typecheck   # ✅
pnpm -r run lingui:extract  # 差分は #: 行番号のみ
```

実機（iOS / Android）で目視チェック済み。