### PR TITLE
refactor: ThemeContext の scheme を colorScheme にリネーム

### DIFF
--- a/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
@@ -4,11 +4,11 @@ import { buildStackScreenOptions } from "../../../theme/navigationScreenOptions"
 import { useLingui } from "@lingui/react/macro";
 
 export default function SettingsLayout() {
-  const { scheme, colors } = useTheme();
+  const { colorScheme, colors } = useTheme();
   const { t } = useLingui();
 
   return (
-    <Stack screenOptions={buildStackScreenOptions(colors, scheme)}>
+    <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
       <Stack.Screen name="index" options={{ title: t`設定` }} />
       <Stack.Screen name="theme" options={{ title: t`テーマ` }} />
     </Stack>

--- a/apps/sandbox/src/app/_layout.tsx
+++ b/apps/sandbox/src/app/_layout.tsx
@@ -22,13 +22,13 @@ import { useLingui } from "@lingui/react/macro";
 initializeI18n();
 
 function RootLayoutContent() {
-  const { scheme, colors } = useTheme();
+  const { colorScheme, colors } = useTheme();
   const { t } = useLingui();
 
   return (
     <>
-      <StatusBar style={scheme === "dark" ? "light" : "dark"} />
-      <Stack screenOptions={buildStackScreenOptions(colors, scheme)}>
+      <StatusBar style={colorScheme === "dark" ? "light" : "dark"} />
+      <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false, title: t`ホーム` }} />
         <Stack.Screen
           name="navigation-patterns/index"

--- a/apps/sandbox/src/theme/ThemeContext.tsx
+++ b/apps/sandbox/src/theme/ThemeContext.tsx
@@ -13,7 +13,7 @@ const STORAGE_KEY = {
 export interface ThemeContextValue {
   mode: ThemeMode;
   setMode: (mode: ThemeMode) => void;
-  scheme: ColorScheme;
+  colorScheme: ColorScheme;
   colors: ColorTokens;
 }
 
@@ -28,16 +28,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const stored = Storage.getItemSync(STORAGE_KEY.THEME_MODE);
     return isValidThemeMode(stored) ? stored : "system";
   });
-  const colorScheme = useColorScheme();
+  const systemColorScheme = useColorScheme();
 
-  const scheme: ColorScheme = useMemo(() => {
+  const colorScheme: ColorScheme = useMemo(() => {
     if (mode === "system") {
-      return colorScheme === "dark" ? "dark" : "light";
+      return systemColorScheme === "dark" ? "dark" : "light";
     }
     return mode;
-  }, [mode, colorScheme]);
+  }, [mode, systemColorScheme]);
 
-  const colors = Colors[scheme];
+  const colors = Colors[colorScheme];
 
   const handleSetMode = useCallback((newMode: ThemeMode) => {
     setMode(newMode);
@@ -48,10 +48,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     () => ({
       mode,
       setMode: handleSetMode,
-      scheme,
+      colorScheme,
       colors,
     }),
-    [mode, handleSetMode, scheme, colors],
+    [mode, handleSetMode, colorScheme, colors],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/apps/sandbox/src/theme/navigationScreenOptions.ts
+++ b/apps/sandbox/src/theme/navigationScreenOptions.ts
@@ -8,11 +8,11 @@ interface StackScreenOptions {
 
 export function buildStackScreenOptions(
   colors: ColorTokens,
-  scheme: ColorScheme,
+  colorScheme: ColorScheme,
 ): StackScreenOptions {
   return {
     headerStyle: { backgroundColor: colors.backgroundHeader },
     headerTintColor: colors.text,
-    headerShadowVisible: scheme === "light",
+    headerShadowVisible: colorScheme === "light",
   };
 }

--- a/apps/sandbox/src/theme/useTheme.ts
+++ b/apps/sandbox/src/theme/useTheme.ts
@@ -1,7 +1,7 @@
 import type { ColorScheme, ColorTokens } from "../constants/theme";
 import { useThemeContextInternal } from "./ThemeContext";
 
-export function useTheme(): { scheme: ColorScheme; colors: ColorTokens } {
-  const { scheme, colors } = useThemeContextInternal();
-  return { scheme, colors };
+export function useTheme(): { colorScheme: ColorScheme; colors: ColorTokens } {
+  const { colorScheme, colors } = useThemeContextInternal();
+  return { colorScheme, colors };
 }


### PR DESCRIPTION
## 概要

ThemeContext が公開していた実効カラースキームのキー `scheme` を `colorScheme` にリネームする。挙動の変更はなく、命名のみの整理。

## 背景・動機

ThemeContext は mode を解決した実効カラースキームを `scheme: "light" | "dark"` として公開していたが、`scheme` 単独では「何の scheme か」が曖昧で、ユーザー選択値 `mode` との関係も読み取りにくかった。

`colorScheme` にリネームすることで以下を狙う:

- React Native の `useColorScheme()` 戻り値型 `ColorSchemeName` と語彙を揃え、エコシステム標準語彙との整合を取る
- 利用側で `colorScheme === "dark"` と直感的に読めるようにする
- `mode`（ユーザー選択値）と `colorScheme`（実効値）の対比を明確にする

## アプローチ

ThemeContextValue のキー `scheme` を `colorScheme` にリネームし、消費側（`useTheme` / `buildStackScreenOptions` / 2 つの `_layout.tsx`）を追従。

ThemeContext.tsx 内部で RN `useColorScheme()` 戻り値を受けていたローカル変数 `colorScheme` は公開キーと衝突するため `systemColorScheme` にリネームして区別した。

### 検討した代替案

- `resolvedScheme` / `activeScheme`: 「mode を解決した結果」という内部実装の都合を呼び出し側に押し付ける命名のため却下
- `appearance`: iOS 寄りの用語で、RN/Web/Android 横断のコードベースにはそぐわないため却下

## レビューポイント

- 公開 API の命名変更のみで、`mode` / `setMode` / `colors` / `useThemeMode` / `ColorScheme` 型エイリアスは変更なし
- `pnpm -r run typecheck` / `pnpm -r run lint` はパス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)