### PR TITLE
fix: iOS ダークモード時の NativeTabs ヘッダー／タブバーのちらつきを修正

### DIFF
--- a/apps/sandbox/src/app/(tabs)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/_layout.tsx
@@ -1,34 +1,40 @@
 import { NativeTabs } from "expo-router/unstable-native-tabs";
+import { DarkTheme, DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import { useLingui } from "@lingui/react/macro";
 import { useTheme } from "../../theme/useTheme";
 
 export default function TabLayout() {
-  const { colors } = useTheme();
+  const { colors, colorScheme } = useTheme();
   const { t } = useLingui();
 
+  // iOS 26 のダークモードで NativeTabs の liquid glass ヘッダーが
+  // ちらつく問題への対処。React Navigation のテーマをカラースキームに揃える。
+  // 参照: https://docs.expo.dev/router/advanced/native-tabs/#common-problems
   return (
-    <NativeTabs
-      backgroundColor={colors.background}
-      tintColor={colors.text}
-      iconColor={{ default: colors.textSecondary, selected: colors.text }}
-      labelStyle={{
-        default: { color: colors.textSecondary },
-        selected: { color: colors.text, fontWeight: "600" },
-      }}
-      indicatorColor={colors.backgroundElement}
-    >
-      <NativeTabs.Trigger name="index">
-        <NativeTabs.Trigger.Icon sf={{ default: "house", selected: "house.fill" }} md="home" />
-        <NativeTabs.Trigger.Label>{t`ホーム`}</NativeTabs.Trigger.Label>
-      </NativeTabs.Trigger>
+    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+      <NativeTabs
+        backgroundColor={colors.background}
+        tintColor={colors.text}
+        iconColor={{ default: colors.textSecondary, selected: colors.text }}
+        labelStyle={{
+          default: { color: colors.textSecondary },
+          selected: { color: colors.text, fontWeight: "600" },
+        }}
+        indicatorColor={colors.backgroundElement}
+      >
+        <NativeTabs.Trigger name="index">
+          <NativeTabs.Trigger.Icon sf={{ default: "house", selected: "house.fill" }} md="home" />
+          <NativeTabs.Trigger.Label>{t`ホーム`}</NativeTabs.Trigger.Label>
+        </NativeTabs.Trigger>
 
-      <NativeTabs.Trigger name="settings">
-        <NativeTabs.Trigger.Icon
-          sf={{ default: "gearshape", selected: "gearshape.fill" }}
-          md="settings"
-        />
-        <NativeTabs.Trigger.Label>{t`設定`}</NativeTabs.Trigger.Label>
-      </NativeTabs.Trigger>
-    </NativeTabs>
+        <NativeTabs.Trigger name="settings">
+          <NativeTabs.Trigger.Icon
+            sf={{ default: "gearshape", selected: "gearshape.fill" }}
+            md="settings"
+          />
+          <NativeTabs.Trigger.Label>{t`設定`}</NativeTabs.Trigger.Label>
+        </NativeTabs.Trigger>
+      </NativeTabs>
+    </ThemeProvider>
   );
 }

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -145,7 +145,7 @@ msgid "フォームを送信"
 msgstr "Submit Form"
 
 #: src/app/_layout.tsx:32
-#: src/app/(tabs)/_layout.tsx:22
+#: src/app/(tabs)/_layout.tsx:27
 msgid "ホーム"
 msgstr "Home"
 
@@ -219,7 +219,7 @@ msgstr "Enter name"
 msgid "完了"
 msgstr "Done"
 
-#: src/app/(tabs)/_layout.tsx:30
+#: src/app/(tabs)/_layout.tsx:35
 #: src/app/(tabs)/settings/_layout.tsx:12
 msgid "設定"
 msgstr "Settings"

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -145,7 +145,7 @@ msgid "フォームを送信"
 msgstr "フォームを送信"
 
 #: src/app/_layout.tsx:32
-#: src/app/(tabs)/_layout.tsx:22
+#: src/app/(tabs)/_layout.tsx:27
 msgid "ホーム"
 msgstr "ホーム"
 
@@ -219,7 +219,7 @@ msgstr "名前を入力"
 msgid "完了"
 msgstr "完了"
 
-#: src/app/(tabs)/_layout.tsx:30
+#: src/app/(tabs)/_layout.tsx:35
 #: src/app/(tabs)/settings/_layout.tsx:12
 msgid "設定"
 msgstr "設定"

--- a/apps/sandbox/src/theme/ThemeContext.tsx
+++ b/apps/sandbox/src/theme/ThemeContext.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
-import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
-import { useColorScheme } from "react-native";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { Appearance, useColorScheme } from "react-native";
 import Storage from "expo-sqlite/kv-store";
 import { Colors, type ColorScheme, type ColorTokens } from "../constants/theme";
 
@@ -38,6 +38,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, [mode, systemColorScheme]);
 
   const colors = Colors[colorScheme];
+
+  // iOS の overrideUserInterfaceStyle をアプリ設定に揃える。
+  // これをやらないと NativeTabs などのネイティブ UI が OS 設定側を
+  // 参照し続け、アプリ内でダーク強制してもタブ切替時にライト色が
+  // ちらつく。"unspecified" を渡すと OS 設定に戻る。
+  useEffect(() => {
+    Appearance.setColorScheme(mode === "system" ? "unspecified" : mode);
+  }, [mode]);
 
   const handleSetMode = useCallback((newMode: ThemeMode) => {
     setMode(newMode);


### PR DESCRIPTION
## 概要

iOS 26 のダークモード時に `NativeTabs` の liquid glass ヘッダーやタブバー背景がライトモードに転倒・ちらつく事象を修正します。OS とアプリで異なるカラーモードを強制したときに発生するケースも含めて対応します。

## 背景

- iOS 26 のダーク環境で `NativeTabs` のヘッダーボタンや、タブ往復時のタブバー背景がライトに転倒する事象を確認
- 公式ドキュメント [Native Tabs - Common problems](https://docs.expo.dev/router/advanced/native-tabs/#common-problems) 記載のワークアラウンドだけでは「OS=light × アプリ=dark」のような食い違いケースをカバーできなかった

## 修正内容

別レイヤーへの対処を 2 コミットに分けています。

### 1. JS テーマ整合 (`(tabs)/_layout.tsx`)

`@react-navigation/native` の `ThemeProvider` で `NativeTabs` を wrap し、`useTheme()` の `colorScheme` に応じて `DarkTheme` / `DefaultTheme` を渡します。公式ガイド準拠の対応です。

> 配置は公式例どおり `(tabs)/_layout.tsx` 内に限定。Root に上げると Stack の未指定領域（cardStyle 背景色など）が navigation テーマ連動になり、既存見た目への回帰リスクがあるため。

### 2. ネイティブ trait 同期 (`ThemeContext.tsx`)

`mode` 変更時に `Appearance.setColorScheme()` を呼び、`UIWindow.overrideUserInterfaceStyle` をアプリ側モードに上書きします。`react-native-screens@4.23.x` が `NativeTabs` の背景に使う `systemBackgroundColor` は trait collection 依存であり、`UIWindow` の trait が OS 設定のままだとアプリのモードが反映されないためです。`mode === "system"` の場合は `"unspecified"` を渡して OS 追従へ戻します。

## レビューポイント

- `Appearance.setColorScheme()` 経由でネイティブ trait を上書きするため、`NativeTabs` 以外のネイティブ UI（StatusBar 等）にも影響します
- iOS 26.2 実機で `Appearance.setColorScheme` 後に再描画で色が転倒する残存報告あり（[#40389](https://redirect.github.com/expo/expo/issues/40389) のコメント by `fleck`）。実機検証で再発した場合は別途追加対策を検討します

## 関連 issue

- [expo/expo#40389](https://redirect.github.com/expo/expo/issues/40389)（OPEN）— 今回の症状そのもの。コミュニティの合意ワークアラウンドが本 PR の方針と一致
- [expo/expo#39969](https://redirect.github.com/expo/expo/issues/39969)（CLOSED）— `react-native-screens` の hardcoded `whiteColor` 問題（upstream 修正済）
- [expo/expo#41743](https://redirect.github.com/expo/expo/issues/41743)（OPEN）— タブ往復で白エッジが出る派生症状

## テスト

- [x] `pnpm -r run typecheck`
- [x] `pnpm -r run lint`
- [ ] iOS 実機/シミュレータでの目視確認
  - [ ] iOS=light + アプリ=dark でタブ往復 → ダーク維持
  - [ ] iOS=dark + アプリ=light でタブ往復 → ライト維持
  - [ ] アプリ=system → OS 設定に追従