### PR TITLE
refactor: Expo Router 画面オプションを Composition components に移行

### DIFF
--- a/apps/sandbox/src/app/(tabs)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/_layout.tsx
@@ -1,3 +1,4 @@
+import { Stack } from "expo-router";
 import { NativeTabs } from "expo-router/unstable-native-tabs";
 import { DarkTheme, DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import { useLingui } from "@lingui/react/macro";
@@ -11,30 +12,36 @@ export default function TabLayout() {
   // ちらつく問題への対処。React Navigation のテーマをカラースキームに揃える。
   // 参照: https://docs.expo.dev/router/advanced/native-tabs/#common-problems
   return (
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <NativeTabs
-        backgroundColor={colors.background}
-        tintColor={colors.text}
-        iconColor={{ default: colors.textSecondary, selected: colors.text }}
-        labelStyle={{
-          default: { color: colors.textSecondary },
-          selected: { color: colors.text, fontWeight: "600" },
-        }}
-        indicatorColor={colors.backgroundElement}
-      >
-        <NativeTabs.Trigger name="index">
-          <NativeTabs.Trigger.Icon sf={{ default: "house", selected: "house.fill" }} md="home" />
-          <NativeTabs.Trigger.Label>{t`ホーム`}</NativeTabs.Trigger.Label>
-        </NativeTabs.Trigger>
+    <>
+      {/* 親 Stack の (tabs) エントリの title。
+          NativeTabs 側はヘッダー非表示なのでここでの title は親 Stack の
+          戻るボタンラベルとして使われる（navigation-patterns 等へ push 時）。 */}
+      <Stack.Screen.Title>{t`ホーム`}</Stack.Screen.Title>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <NativeTabs
+          backgroundColor={colors.background}
+          tintColor={colors.text}
+          iconColor={{ default: colors.textSecondary, selected: colors.text }}
+          labelStyle={{
+            default: { color: colors.textSecondary },
+            selected: { color: colors.text, fontWeight: "600" },
+          }}
+          indicatorColor={colors.backgroundElement}
+        >
+          <NativeTabs.Trigger name="index">
+            <NativeTabs.Trigger.Icon sf={{ default: "house", selected: "house.fill" }} md="home" />
+            <NativeTabs.Trigger.Label>{t`ホーム`}</NativeTabs.Trigger.Label>
+          </NativeTabs.Trigger>
 
-        <NativeTabs.Trigger name="settings">
-          <NativeTabs.Trigger.Icon
-            sf={{ default: "gearshape", selected: "gearshape.fill" }}
-            md="settings"
-          />
-          <NativeTabs.Trigger.Label>{t`設定`}</NativeTabs.Trigger.Label>
-        </NativeTabs.Trigger>
-      </NativeTabs>
-    </ThemeProvider>
+          <NativeTabs.Trigger name="settings">
+            <NativeTabs.Trigger.Icon
+              sf={{ default: "gearshape", selected: "gearshape.fill" }}
+              md="settings"
+            />
+            <NativeTabs.Trigger.Label>{t`設定`}</NativeTabs.Trigger.Label>
+          </NativeTabs.Trigger>
+        </NativeTabs>
+      </ThemeProvider>
+    </>
   );
 }

--- a/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
@@ -1,16 +1,9 @@
 import { Stack } from "expo-router";
 import { useTheme } from "../../../theme/useTheme";
 import { buildStackScreenOptions } from "../../../theme/navigationScreenOptions";
-import { useLingui } from "@lingui/react/macro";
 
 export default function SettingsLayout() {
   const { colorScheme, colors } = useTheme();
-  const { t } = useLingui();
 
-  return (
-    <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
-      <Stack.Screen name="index" options={{ title: t`設定` }} />
-      <Stack.Screen name="theme" options={{ title: t`テーマ` }} />
-    </Stack>
-  );
+  return <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)} />;
 }

--- a/apps/sandbox/src/app/(tabs)/settings/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/index.tsx
@@ -1,7 +1,9 @@
-import { Trans } from "@lingui/react/macro";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { LinkList, type LinkItem } from "../../../components/link-list/LinkList";
 
 export default function SettingsScreen() {
+  const { t } = useLingui();
   const list = [
     {
       href: "/settings/theme",
@@ -9,5 +11,10 @@ export default function SettingsScreen() {
     },
   ] as const satisfies LinkItem[];
 
-  return <LinkList data={list} />;
+  return (
+    <>
+      <Stack.Screen.Title>{t`設定`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
 }

--- a/apps/sandbox/src/app/(tabs)/settings/theme.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/theme.tsx
@@ -1,4 +1,5 @@
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Stack } from "expo-router";
 import type { ThemeMode } from "../../../theme/ThemeContext";
 import { useTheme } from "../../../theme/useTheme";
 import { useThemeMode } from "../../../theme/useThemeMode";
@@ -17,6 +18,7 @@ export default function ThemeScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Stack.Screen.Title>{t`テーマ`}</Stack.Screen.Title>
       {options.map((option) => (
         <Pressable
           key={option.value}

--- a/apps/sandbox/src/app/_layout.tsx
+++ b/apps/sandbox/src/app/_layout.tsx
@@ -16,52 +16,22 @@ import { ThemeProvider } from "../theme/ThemeContext";
 import { useTheme } from "../theme/useTheme";
 import { buildStackScreenOptions } from "../theme/navigationScreenOptions";
 import { initializeI18n } from "../i18n";
-import { useLingui } from "@lingui/react/macro";
 
 // アプリ起動時に一度だけi18nを初期化（デバイスの言語設定を読み込む）
 initializeI18n();
 
 function RootLayoutContent() {
   const { colorScheme, colors } = useTheme();
-  const { t } = useLingui();
 
   return (
     <>
       <StatusBar style={colorScheme === "dark" ? "light" : "dark"} />
       <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false, title: t`ホーム` }} />
-        <Stack.Screen
-          name="navigation-patterns/index"
-          options={{
-            title: t`ナビゲーションパターン`,
-          }}
-        />
-        <Stack.Screen
-          name="navigation-patterns/modal"
-          options={{
-            title: t`モーダルサンプル`,
-          }}
-        />
-        <Stack.Screen
-          name="navigation-patterns/form-sheet"
-          options={{
-            title: t`フォームシートサンプル`,
-          }}
-        />
-        <Stack.Screen
-          name="navigation-patterns/modal-screen"
-          options={{
-            title: t`モーダル画面`,
-            presentation: "modal",
-          }}
-        />
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="navigation-patterns/modal-screen" options={{ presentation: "modal" }} />
         <Stack.Screen
           name="navigation-patterns/form-sheet-screen"
-          options={{
-            title: t`フォームシート画面`,
-            presentation: "formSheet",
-            sheetGrabberVisible: true,
-          }}
+          options={{ presentation: "formSheet", sheetGrabberVisible: true }}
         />
       </Stack>
     </>

--- a/apps/sandbox/src/app/navigation-patterns/form-sheet-screen.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/form-sheet-screen.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, Text, View, Pressable, ScrollView, TextInput, Platform } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import { useTheme } from "../../theme/useTheme";
 import { useState } from "react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -24,6 +24,7 @@ export default function FormSheetScreen() {
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <Stack.Screen.Title>{t`フォームシート画面`}</Stack.Screen.Title>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>
         <View style={styles.header}>
           <Text style={[styles.title, { color: colors.text }]}>

--- a/apps/sandbox/src/app/navigation-patterns/form-sheet.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/form-sheet.tsx
@@ -1,11 +1,12 @@
 import { StyleSheet, Text, View, Pressable } from "react-native";
-import { useRouter } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import { useTheme } from "../../theme/useTheme";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 
 export default function FormSheetSample() {
   const { colors } = useTheme();
   const router = useRouter();
+  const { t } = useLingui();
 
   const openFormSheet = () => {
     router.push("/navigation-patterns/form-sheet-screen");
@@ -13,6 +14,7 @@ export default function FormSheetSample() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Stack.Screen.Title>{t`フォームシートサンプル`}</Stack.Screen.Title>
       <View style={styles.content}>
         <Text style={[styles.title, { color: colors.text }]}>
           <Trans>フォームシート表示サンプル</Trans>

--- a/apps/sandbox/src/app/navigation-patterns/index.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/index.tsx
@@ -1,7 +1,9 @@
+import { Stack } from "expo-router";
 import { LinkList, type LinkItem } from "../../components/link-list/LinkList";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 
 export default function NavigationPatterns() {
+  const { t } = useLingui();
   const list = [
     {
       href: "/navigation-patterns/modal",
@@ -13,5 +15,10 @@ export default function NavigationPatterns() {
     },
   ] as const satisfies LinkItem[];
 
-  return <LinkList data={list} />;
+  return (
+    <>
+      <Stack.Screen.Title>{t`ナビゲーションパターン`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
 }

--- a/apps/sandbox/src/app/navigation-patterns/modal-screen.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/modal-screen.tsx
@@ -1,11 +1,12 @@
 import { StyleSheet, Text, View, Pressable, ScrollView } from "react-native";
-import { useRouter } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import { useTheme } from "../../theme/useTheme";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 
 export default function ModalScreen() {
   const { colors } = useTheme();
   const router = useRouter();
+  const { t } = useLingui();
 
   const closeModal = () => {
     router.back();
@@ -16,6 +17,7 @@ export default function ModalScreen() {
       style={[styles.container, { backgroundColor: colors.background }]}
       contentContainerStyle={styles.contentContainer}
     >
+      <Stack.Screen.Title>{t`モーダル画面`}</Stack.Screen.Title>
       <View style={styles.header}>
         <Text style={[styles.title, { color: colors.text }]}>
           <Trans>モーダル画面</Trans>

--- a/apps/sandbox/src/app/navigation-patterns/modal.tsx
+++ b/apps/sandbox/src/app/navigation-patterns/modal.tsx
@@ -1,11 +1,12 @@
 import { StyleSheet, Text, View, Pressable } from "react-native";
-import { useRouter } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import { useTheme } from "../../theme/useTheme";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 
 export default function ModalSample() {
   const { colors } = useTheme();
   const router = useRouter();
+  const { t } = useLingui();
 
   const openModal = () => {
     router.push("/navigation-patterns/modal-screen");
@@ -13,6 +14,7 @@ export default function ModalSample() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Stack.Screen.Title>{t`モーダルサンプル`}</Stack.Screen.Title>
       <View style={styles.content}>
         <Text style={[styles.title, { color: colors.text }]}>
           <Trans>モーダル表示サンプル</Trans>

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -144,7 +144,8 @@ msgstr "About Form Sheet Display:"
 msgid "フォームを送信"
 msgstr "Submit Form"
 
-#: src/app/(tabs)/_layout.tsx:27
+#: src/app/(tabs)/_layout.tsx:19
+#: src/app/(tabs)/_layout.tsx:33
 msgid "ホーム"
 msgstr "Home"
 
@@ -218,7 +219,7 @@ msgstr "Enter name"
 msgid "完了"
 msgstr "Done"
 
-#: src/app/(tabs)/_layout.tsx:35
+#: src/app/(tabs)/_layout.tsx:41
 #: src/app/(tabs)/settings/index.tsx:16
 msgid "設定"
 msgstr "Settings"

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/navigation-patterns/form-sheet.tsx:44
+#: src/app/navigation-patterns/form-sheet.tsx:46
 msgid ""
 "【iOS】\n"
 "• 画面全体を覆わない小さめのモーダル\n"
@@ -41,19 +41,19 @@ msgstr ""
 "【Common】\n"
 "• Can be closed with a downward swipe gesture"
 
-#: src/app/navigation-patterns/modal-screen.tsx:51
+#: src/app/navigation-patterns/modal-screen.tsx:53
 msgid "• 「閉じる」ボタンをタップ"
 msgstr "• Tap the \"Close\" button"
 
-#: src/app/navigation-patterns/modal-screen.tsx:54
+#: src/app/navigation-patterns/modal-screen.tsx:56
 msgid "• 上から下へスワイプ（iOS）"
 msgstr "• Swipe down from top (iOS)"
 
-#: src/app/navigation-patterns/modal-screen.tsx:57
+#: src/app/navigation-patterns/modal-screen.tsx:59
 msgid "• 戻るジェスチャーを使用（Android）"
 msgstr "• Use back gesture (Android)"
 
-#: src/app/navigation-patterns/modal.tsx:44
+#: src/app/navigation-patterns/modal.tsx:46
 msgid ""
 "• 画面全体を覆います\n"
 "• 下から上へアニメーションします\n"
@@ -65,165 +65,164 @@ msgstr ""
 "• Can be closed with a downward swipe gesture\n"
 "• Blocks interaction with the parent screen"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:38
+#: src/app/navigation-patterns/form-sheet-screen.tsx:39
 msgid "キャンセル"
 msgstr "Cancel"
 
-#: src/app/navigation-patterns/modal-screen.tsx:66
+#: src/app/navigation-patterns/modal-screen.tsx:68
 msgid "このモーダルにはフォーム、画像、インタラクティブな要素など、 あらゆるコンテンツを含めることができます。"
 msgstr "This modal can contain any content such as forms, images, interactive elements, and more."
 
-#: src/app/navigation-patterns/modal-screen.tsx:44
+#: src/app/navigation-patterns/modal-screen.tsx:46
 msgid "この画面はモーダル表示スタイルで表示されています。 以下の方法で閉じることができます："
 msgstr "This screen is displayed in modal presentation style. You can close it in the following ways:"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:63
+#: src/app/navigation-patterns/form-sheet-screen.tsx:64
 msgid "これはフォームシートで表示されたフォームのデモです。 背景に親画面が見えることに注目してください。"
 msgstr "This is a form demo displayed in a form sheet. Notice that you can see the parent screen in the background."
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:68
+#: src/app/navigation-patterns/form-sheet-screen.tsx:69
 msgid "これはモーダルで表示されたフォームのデモです。"
 msgstr "This is a form demo displayed in a modal."
 
-#: src/app/navigation-patterns/modal-screen.tsx:40
+#: src/app/navigation-patterns/modal-screen.tsx:42
 msgid "これはモーダル表示です"
 msgstr "This is a Modal Display"
 
-#: src/app/(tabs)/settings/theme.tsx:13
+#: src/app/(tabs)/settings/theme.tsx:14
 msgid "システム設定に従う"
 msgstr "Follow system settings"
 
-#: src/app/(tabs)/settings/theme.tsx:15
+#: src/app/(tabs)/settings/theme.tsx:16
 msgid "ダーク"
 msgstr "Dark"
 
-#: src/app/(tabs)/settings/_layout.tsx:13
-#: src/app/(tabs)/settings/index.tsx:8
+#: src/app/(tabs)/settings/index.tsx:10
+#: src/app/(tabs)/settings/theme.tsx:21
 msgid "テーマ"
 msgstr "Theme"
 
-#: src/app/navigation-patterns/modal-screen.tsx:63
+#: src/app/navigation-patterns/modal-screen.tsx:65
 msgid "デモコンテンツ"
 msgstr "Demo Content"
 
-#: src/app/_layout.tsx:36
 #: src/app/(tabs)/index.tsx:9
+#: src/app/navigation-patterns/index.tsx:20
 msgid "ナビゲーションパターン"
 msgstr "Navigation Patterns"
 
-#: src/app/_layout.tsx:48
+#: src/app/navigation-patterns/form-sheet.tsx:17
 msgid "フォームシートサンプル"
 msgstr "Form Sheet Sample"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:30
+#: src/app/navigation-patterns/form-sheet-screen.tsx:31
 msgid "フォームシートの例"
 msgstr "Form Sheet Example"
 
-#: src/app/navigation-patterns/form-sheet.tsx:35
+#: src/app/navigation-patterns/form-sheet.tsx:37
 msgid "フォームシートを開く"
 msgstr "Open Form Sheet"
 
-#: src/app/_layout.tsx:61
+#: src/app/navigation-patterns/form-sheet-screen.tsx:27
 msgid "フォームシート画面"
 msgstr "Form Sheet Screen"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:55
-#: src/app/navigation-patterns/index.tsx:12
+#: src/app/navigation-patterns/form-sheet-screen.tsx:56
+#: src/app/navigation-patterns/index.tsx:14
 msgid "フォームシート表示"
 msgstr "Form Sheet Display"
 
-#: src/app/navigation-patterns/form-sheet.tsx:18
+#: src/app/navigation-patterns/form-sheet.tsx:20
 msgid "フォームシート表示サンプル"
 msgstr "Form Sheet Display Sample"
 
-#: src/app/navigation-patterns/form-sheet.tsx:41
+#: src/app/navigation-patterns/form-sheet.tsx:43
 msgid "フォームシート表示について："
 msgstr "About Form Sheet Display:"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:149
+#: src/app/navigation-patterns/form-sheet-screen.tsx:150
 msgid "フォームを送信"
 msgstr "Submit Form"
 
-#: src/app/_layout.tsx:32
 #: src/app/(tabs)/_layout.tsx:27
 msgid "ホーム"
 msgstr "Home"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:95
+#: src/app/navigation-patterns/form-sheet-screen.tsx:96
 msgid "メールアドレス"
 msgstr "Email Address"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:108
+#: src/app/navigation-patterns/form-sheet-screen.tsx:109
 msgid "メールアドレスを入力"
 msgstr "Enter email address"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:117
+#: src/app/navigation-patterns/form-sheet-screen.tsx:118
 msgid "メッセージ"
 msgstr "Message"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:130
+#: src/app/navigation-patterns/form-sheet-screen.tsx:131
 msgid "メッセージを入力"
 msgstr "Enter message"
 
-#: src/app/_layout.tsx:42
+#: src/app/navigation-patterns/modal.tsx:17
 msgid "モーダルサンプル"
 msgstr "Modal Sample"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:57
+#: src/app/navigation-patterns/form-sheet-screen.tsx:58
 msgid "モーダルフォーム（Android）"
 msgstr "Modal Form (Android)"
 
-#: src/app/navigation-patterns/modal.tsx:35
+#: src/app/navigation-patterns/modal.tsx:37
 msgid "モーダルを開く"
 msgstr "Open Modal"
 
-#: src/app/_layout.tsx:54
-#: src/app/navigation-patterns/modal-screen.tsx:21
+#: src/app/navigation-patterns/modal-screen.tsx:20
+#: src/app/navigation-patterns/modal-screen.tsx:23
 msgid "モーダル画面"
 msgstr "Modal Screen"
 
-#: src/app/navigation-patterns/index.tsx:8
+#: src/app/navigation-patterns/index.tsx:10
 msgid "モーダル表示"
 msgstr "Modal Display"
 
-#: src/app/navigation-patterns/modal.tsx:18
+#: src/app/navigation-patterns/modal.tsx:20
 msgid "モーダル表示サンプル"
 msgstr "Modal Display Sample"
 
-#: src/app/navigation-patterns/modal.tsx:41
+#: src/app/navigation-patterns/modal.tsx:43
 msgid "モーダル表示について："
 msgstr "About Modal Display:"
 
-#: src/app/(tabs)/settings/theme.tsx:14
+#: src/app/(tabs)/settings/theme.tsx:15
 msgid "ライト"
 msgstr "Light"
 
-#: src/app/navigation-patterns/form-sheet.tsx:22
+#: src/app/navigation-patterns/form-sheet.tsx:24
 msgid "下のボタンをタップしてフォームシート表示で画面を開きます。"
 msgstr "Tap the button below to open a screen in form sheet display."
 
-#: src/app/navigation-patterns/modal.tsx:22
+#: src/app/navigation-patterns/modal.tsx:24
 msgid "下のボタンをタップしてモーダル表示で画面を開きます。"
 msgstr "Tap the button below to open a screen in modal display."
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:75
+#: src/app/navigation-patterns/form-sheet-screen.tsx:76
 msgid "名前"
 msgstr "Name"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:88
+#: src/app/navigation-patterns/form-sheet-screen.tsx:89
 msgid "名前を入力"
 msgstr "Enter name"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:46
-#: src/app/navigation-patterns/modal-screen.tsx:83
+#: src/app/navigation-patterns/form-sheet-screen.tsx:47
+#: src/app/navigation-patterns/modal-screen.tsx:85
 msgid "完了"
 msgstr "Done"
 
 #: src/app/(tabs)/_layout.tsx:35
-#: src/app/(tabs)/settings/_layout.tsx:12
+#: src/app/(tabs)/settings/index.tsx:16
 msgid "設定"
 msgstr "Settings"
 
-#: src/app/navigation-patterns/modal-screen.tsx:33
+#: src/app/navigation-patterns/modal-screen.tsx:35
 msgid "閉じる"
 msgstr "Close"

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -144,7 +144,8 @@ msgstr "フォームシート表示について："
 msgid "フォームを送信"
 msgstr "フォームを送信"
 
-#: src/app/(tabs)/_layout.tsx:27
+#: src/app/(tabs)/_layout.tsx:19
+#: src/app/(tabs)/_layout.tsx:33
 msgid "ホーム"
 msgstr "ホーム"
 
@@ -218,7 +219,7 @@ msgstr "名前を入力"
 msgid "完了"
 msgstr "完了"
 
-#: src/app/(tabs)/_layout.tsx:35
+#: src/app/(tabs)/_layout.tsx:41
 #: src/app/(tabs)/settings/index.tsx:16
 msgid "設定"
 msgstr "設定"

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/app/navigation-patterns/form-sheet.tsx:44
+#: src/app/navigation-patterns/form-sheet.tsx:46
 msgid ""
 "【iOS】\n"
 "• 画面全体を覆わない小さめのモーダル\n"
@@ -41,19 +41,19 @@ msgstr ""
 "【共通】\n"
 "• 下へのスワイプジェスチャーで閉じることができます"
 
-#: src/app/navigation-patterns/modal-screen.tsx:51
+#: src/app/navigation-patterns/modal-screen.tsx:53
 msgid "• 「閉じる」ボタンをタップ"
 msgstr "• 「閉じる」ボタンをタップ"
 
-#: src/app/navigation-patterns/modal-screen.tsx:54
+#: src/app/navigation-patterns/modal-screen.tsx:56
 msgid "• 上から下へスワイプ（iOS）"
 msgstr "• 上から下へスワイプ（iOS）"
 
-#: src/app/navigation-patterns/modal-screen.tsx:57
+#: src/app/navigation-patterns/modal-screen.tsx:59
 msgid "• 戻るジェスチャーを使用（Android）"
 msgstr "• 戻るジェスチャーを使用（Android）"
 
-#: src/app/navigation-patterns/modal.tsx:44
+#: src/app/navigation-patterns/modal.tsx:46
 msgid ""
 "• 画面全体を覆います\n"
 "• 下から上へアニメーションします\n"
@@ -65,165 +65,164 @@ msgstr ""
 "• 下へのスワイプジェスチャーで閉じることができます\n"
 "• 親画面との対話をブロックします"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:38
+#: src/app/navigation-patterns/form-sheet-screen.tsx:39
 msgid "キャンセル"
 msgstr "キャンセル"
 
-#: src/app/navigation-patterns/modal-screen.tsx:66
+#: src/app/navigation-patterns/modal-screen.tsx:68
 msgid "このモーダルにはフォーム、画像、インタラクティブな要素など、 あらゆるコンテンツを含めることができます。"
 msgstr "このモーダルにはフォーム、画像、インタラクティブな要素など、 あらゆるコンテンツを含めることができます。"
 
-#: src/app/navigation-patterns/modal-screen.tsx:44
+#: src/app/navigation-patterns/modal-screen.tsx:46
 msgid "この画面はモーダル表示スタイルで表示されています。 以下の方法で閉じることができます："
 msgstr "この画面はモーダル表示スタイルで表示されています。 以下の方法で閉じることができます："
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:63
+#: src/app/navigation-patterns/form-sheet-screen.tsx:64
 msgid "これはフォームシートで表示されたフォームのデモです。 背景に親画面が見えることに注目してください。"
 msgstr "これはフォームシートで表示されたフォームのデモです。 背景に親画面が見えることに注目してください。"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:68
+#: src/app/navigation-patterns/form-sheet-screen.tsx:69
 msgid "これはモーダルで表示されたフォームのデモです。"
 msgstr "これはモーダルで表示されたフォームのデモです。"
 
-#: src/app/navigation-patterns/modal-screen.tsx:40
+#: src/app/navigation-patterns/modal-screen.tsx:42
 msgid "これはモーダル表示です"
 msgstr "これはモーダル表示です"
 
-#: src/app/(tabs)/settings/theme.tsx:13
+#: src/app/(tabs)/settings/theme.tsx:14
 msgid "システム設定に従う"
 msgstr "システム設定に従う"
 
-#: src/app/(tabs)/settings/theme.tsx:15
+#: src/app/(tabs)/settings/theme.tsx:16
 msgid "ダーク"
 msgstr "ダーク"
 
-#: src/app/(tabs)/settings/_layout.tsx:13
-#: src/app/(tabs)/settings/index.tsx:8
+#: src/app/(tabs)/settings/index.tsx:10
+#: src/app/(tabs)/settings/theme.tsx:21
 msgid "テーマ"
 msgstr "テーマ"
 
-#: src/app/navigation-patterns/modal-screen.tsx:63
+#: src/app/navigation-patterns/modal-screen.tsx:65
 msgid "デモコンテンツ"
 msgstr "デモコンテンツ"
 
-#: src/app/_layout.tsx:36
 #: src/app/(tabs)/index.tsx:9
+#: src/app/navigation-patterns/index.tsx:20
 msgid "ナビゲーションパターン"
 msgstr "ナビゲーションパターン"
 
-#: src/app/_layout.tsx:48
+#: src/app/navigation-patterns/form-sheet.tsx:17
 msgid "フォームシートサンプル"
 msgstr "フォームシートサンプル"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:30
+#: src/app/navigation-patterns/form-sheet-screen.tsx:31
 msgid "フォームシートの例"
 msgstr "フォームシートの例"
 
-#: src/app/navigation-patterns/form-sheet.tsx:35
+#: src/app/navigation-patterns/form-sheet.tsx:37
 msgid "フォームシートを開く"
 msgstr "フォームシートを開く"
 
-#: src/app/_layout.tsx:61
+#: src/app/navigation-patterns/form-sheet-screen.tsx:27
 msgid "フォームシート画面"
 msgstr "フォームシート画面"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:55
-#: src/app/navigation-patterns/index.tsx:12
+#: src/app/navigation-patterns/form-sheet-screen.tsx:56
+#: src/app/navigation-patterns/index.tsx:14
 msgid "フォームシート表示"
 msgstr "フォームシート表示"
 
-#: src/app/navigation-patterns/form-sheet.tsx:18
+#: src/app/navigation-patterns/form-sheet.tsx:20
 msgid "フォームシート表示サンプル"
 msgstr "フォームシート表示サンプル"
 
-#: src/app/navigation-patterns/form-sheet.tsx:41
+#: src/app/navigation-patterns/form-sheet.tsx:43
 msgid "フォームシート表示について："
 msgstr "フォームシート表示について："
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:149
+#: src/app/navigation-patterns/form-sheet-screen.tsx:150
 msgid "フォームを送信"
 msgstr "フォームを送信"
 
-#: src/app/_layout.tsx:32
 #: src/app/(tabs)/_layout.tsx:27
 msgid "ホーム"
 msgstr "ホーム"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:95
+#: src/app/navigation-patterns/form-sheet-screen.tsx:96
 msgid "メールアドレス"
 msgstr "メールアドレス"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:108
+#: src/app/navigation-patterns/form-sheet-screen.tsx:109
 msgid "メールアドレスを入力"
 msgstr "メールアドレスを入力"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:117
+#: src/app/navigation-patterns/form-sheet-screen.tsx:118
 msgid "メッセージ"
 msgstr "メッセージ"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:130
+#: src/app/navigation-patterns/form-sheet-screen.tsx:131
 msgid "メッセージを入力"
 msgstr "メッセージを入力"
 
-#: src/app/_layout.tsx:42
+#: src/app/navigation-patterns/modal.tsx:17
 msgid "モーダルサンプル"
 msgstr "モーダルサンプル"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:57
+#: src/app/navigation-patterns/form-sheet-screen.tsx:58
 msgid "モーダルフォーム（Android）"
 msgstr "モーダルフォーム（Android）"
 
-#: src/app/navigation-patterns/modal.tsx:35
+#: src/app/navigation-patterns/modal.tsx:37
 msgid "モーダルを開く"
 msgstr "モーダルを開く"
 
-#: src/app/_layout.tsx:54
-#: src/app/navigation-patterns/modal-screen.tsx:21
+#: src/app/navigation-patterns/modal-screen.tsx:20
+#: src/app/navigation-patterns/modal-screen.tsx:23
 msgid "モーダル画面"
 msgstr "モーダル画面"
 
-#: src/app/navigation-patterns/index.tsx:8
+#: src/app/navigation-patterns/index.tsx:10
 msgid "モーダル表示"
 msgstr "モーダル表示"
 
-#: src/app/navigation-patterns/modal.tsx:18
+#: src/app/navigation-patterns/modal.tsx:20
 msgid "モーダル表示サンプル"
 msgstr "モーダル表示サンプル"
 
-#: src/app/navigation-patterns/modal.tsx:41
+#: src/app/navigation-patterns/modal.tsx:43
 msgid "モーダル表示について："
 msgstr "モーダル表示について："
 
-#: src/app/(tabs)/settings/theme.tsx:14
+#: src/app/(tabs)/settings/theme.tsx:15
 msgid "ライト"
 msgstr "ライト"
 
-#: src/app/navigation-patterns/form-sheet.tsx:22
+#: src/app/navigation-patterns/form-sheet.tsx:24
 msgid "下のボタンをタップしてフォームシート表示で画面を開きます。"
 msgstr "下のボタンをタップしてフォームシート表示で画面を開きます。"
 
-#: src/app/navigation-patterns/modal.tsx:22
+#: src/app/navigation-patterns/modal.tsx:24
 msgid "下のボタンをタップしてモーダル表示で画面を開きます。"
 msgstr "下のボタンをタップしてモーダル表示で画面を開きます。"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:75
+#: src/app/navigation-patterns/form-sheet-screen.tsx:76
 msgid "名前"
 msgstr "名前"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:88
+#: src/app/navigation-patterns/form-sheet-screen.tsx:89
 msgid "名前を入力"
 msgstr "名前を入力"
 
-#: src/app/navigation-patterns/form-sheet-screen.tsx:46
-#: src/app/navigation-patterns/modal-screen.tsx:83
+#: src/app/navigation-patterns/form-sheet-screen.tsx:47
+#: src/app/navigation-patterns/modal-screen.tsx:85
 msgid "完了"
 msgstr "完了"
 
 #: src/app/(tabs)/_layout.tsx:35
-#: src/app/(tabs)/settings/_layout.tsx:12
+#: src/app/(tabs)/settings/index.tsx:16
 msgid "設定"
 msgstr "設定"
 
-#: src/app/navigation-patterns/modal-screen.tsx:33
+#: src/app/navigation-patterns/modal-screen.tsx:35
 msgid "閉じる"
 msgstr "閉じる"

--- a/docs/expo-router/screen-options.md
+++ b/docs/expo-router/screen-options.md
@@ -1,0 +1,170 @@
+# Expo Router 画面オプション運用ガイド
+
+このドキュメントは、Expo Router の Stack ナビゲータで画面オプション（`title`, `presentation`, ヘッダースタイル等）をどこにどう書くかの方針をまとめたものです。
+
+## 目次
+
+1. [方針概要](#方針概要)
+2. [使い分けルール](#使い分けルール)
+3. [採用根拠](#採用根拠)
+4. [コードサンプル](#コードサンプル)
+5. [アンチパターン](#アンチパターン)
+6. [将来移行メモ](#将来移行メモ)
+
+## 方針概要
+
+Expo Router は画面オプションを設定する 2 種類の API を提供しています（SDK 55 以降）。
+
+| API | 配置 | 用途 |
+| --- | --- | --- |
+| **Composition components** (例: `<Stack.Screen.Title>`) | 画面ファイル内の JSX | 画面個別の表示に関する options |
+| **Options-based API** (`<Stack.Screen name="..." options={...} />`) | `_layout.tsx` 内 | 構造的 options、共通設定 |
+
+本プロジェクトでは **「画面個別の関心事は Composition で画面ファイルに co-locate」「ナビゲータが事前に把握すべき構造的設定は `_layout.tsx` に集約」** という役割分担を採用しています。
+
+## 使い分けルール
+
+### 画面ファイル側（Composition components）に書く
+
+画面ファイル（`src/app/.../<screen>.tsx`）の返却 JSX 内に `<Stack.Screen.Title>` などを配置します。
+
+- **`title`**: `<Stack.Screen.Title>{t\`画面タイトル\`}</Stack.Screen.Title>`
+- 将来採用予定の以下も画面ファイル側になります（必要になった時点で追加）
+  - `Stack.Screen.BackButton` - 戻るボタンのカスタマイズ
+  - `Stack.Toolbar` - ヘッダー右側のボタンや bottom toolbar（**bottom toolbar は画面ファイル限定**、layout 側では使用不可）
+  - `Stack.Header` - ヘッダー全体のカスタマイズ
+
+### `_layout.tsx` 側（Options-based API）に書く
+
+構造的に親 Stack ナビゲータが画面マウント前に把握しなければならない options は `_layout.tsx` の `<Stack.Screen name="..." options={...} />` で宣言します。
+
+- **`presentation: "modal" / "formSheet" / "fullScreenModal"`** - 画面の表示モード
+- **`sheetGrabberVisible`**, **`sheetAllowedDetents`** など formSheet 関連
+- **`headerShown: false`** - グループ全体のヘッダー非表示
+- **`animation`** - 一部の値は初回不適用になる可能性があるため layout 側推奨
+- **画面ファイル単独では取れない設定全般**
+
+### `<Stack screenOptions={...}>` に書く
+
+全画面共通のヘッダースタイル（色、フォント等）は `<Stack>` の `screenOptions` prop で一括指定します。本プロジェクトでは `buildStackScreenOptions(colors, colorScheme)` ユーティリティで集約しています。
+
+## 採用根拠
+
+### Expo の方向性
+
+1. **SDK 56 で API 整理が継続**: SDK 56.0.0 changelog に "Rename `Stack.Screen.Title` to `Stack.Title`. The old name is kept as a deprecated alias." とあり、Composition components API は廃止対象ではなく整理・洗練の対象。
+2. **新機能は composition 側に乗っている**: SDK 56 で追加された Android Stack.Toolbar、Header Toolbar、Liquid Glass headers などはすべて Composition components 設計。
+3. **page-component 限定機能の存在**: `Stack.Toolbar` の bottom toolbar は公式に "can only be used inside page components, not in layout files." と明文化されており、画面ファイル前提アーキテクチャに移行している。
+4. **`asChild` プロパティ**: Radix UI 風の modern composition パターンを採用、custom title component を画面側で組み立てやすい設計。
+
+### プロジェクト方針との整合
+
+- CLAUDE.md の「ディレクトリ構造は機能で分類し co-location を採用する」と整合
+- 画面追加・削除時に `_layout.tsx` を編集する必要がなく、画面ファイル単独で完結
+- 動的な title（route params 連動など）が将来必要になった場合に同じ場所で書ける
+
+### `presentation` が画面ファイル側で動作しない理由
+
+`presentation` はネイティブ Stack が画面をどう生成・遷移させるかを決める設定で、画面コンテンツが render される **前** に親ナビゲータが知っている必要があります。画面ファイル内の `<Stack.Screen options>` は screen 自身がマウントされた **後** に options を更新するため、初回 presentation には間に合いません。issue [expo/router#630](https://github.com/expo/router/issues/630) で Expo Router の core contributor (EvanBacon) が明示的に "you cannot modally present a screen from a different stack inside the current stack" と回答しており、`_layout.tsx` 側での宣言が必須です。
+
+## コードサンプル
+
+### 画面ファイル: title を Composition で配置
+
+```tsx
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList } from "../../components/link-list/LinkList";
+
+export default function NavigationPatterns() {
+  const { t } = useLingui();
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`ナビゲーションパターン`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}
+```
+
+ポイント:
+- Fragment (`<>...</>`) で wrap し、Screen.Title を兄弟要素として配置
+- i18n は `useLingui()` の `t` テンプレートリテラルを使う（`_layout.tsx` と同じパターン）
+- メッセージ内容は文字列で渡す（`<Trans>` は内部で React element を返すため Title の string children には使えない）
+
+### `_layout.tsx`: 構造的 options のみ宣言
+
+```tsx
+import { Stack } from "expo-router";
+import { useTheme } from "../theme/useTheme";
+import { buildStackScreenOptions } from "../theme/navigationScreenOptions";
+
+export default function RootLayout() {
+  const { colorScheme, colors } = useTheme();
+
+  return (
+    <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
+      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="navigation-patterns/modal-screen"
+        options={{ presentation: "modal" }}
+      />
+      <Stack.Screen
+        name="navigation-patterns/form-sheet-screen"
+        options={{ presentation: "formSheet", sheetGrabberVisible: true }}
+      />
+    </Stack>
+  );
+}
+```
+
+ポイント:
+- title 宣言は不要（各画面ファイルで自己申告）
+- 通常画面の `<Stack.Screen name>` 宣言も不要（ファイルシステムから自動登録）
+- 残るのは構造的設定が必要な画面のみ
+
+## アンチパターン
+
+### 画面ファイル内で `presentation` を指定する
+
+```tsx
+// ❌ 動作しない / 不安定
+export default function ModalScreen() {
+  return (
+    <>
+      <Stack.Screen options={{ presentation: "modal" }} />
+      <ScreenContent />
+    </>
+  );
+}
+```
+
+理由は上記「`presentation` が画面ファイル側で動作しない理由」参照。`screen presentation updated from modal to push error, this may likely result in a screen object leakage` のエラーになるケースも報告されています。
+
+### `<Stack.Screen.Title>` 内で `<Trans>` を使う
+
+```tsx
+// ❌ ネイティブ Title API は React element を受け取らない
+<Stack.Screen.Title>
+  <Trans>タイトル</Trans>
+</Stack.Screen.Title>
+```
+
+`<Stack.Screen.Title>` の `children` は string を想定しています（custom component 化したい場合は `asChild` prop を使う）。i18n には `t` テンプレートリテラルを使ってください。
+
+### Options API と Composition の混在で同じ画面の title を二重指定
+
+`_layout.tsx` の `<Stack.Screen options={{ title }}>` と画面ファイル内の `<Stack.Screen.Title>` を同じ画面に両方書くと、後者が優先されますが意図が分かりにくくなります。プロジェクト方針通り片方に寄せてください。
+
+## 将来移行メモ
+
+### SDK 56 アップグレード時
+
+- **`Stack.Screen.Title` → `Stack.Title` への置換**: SDK 56 で canonical 名が変わりますが、`Stack.Screen.Title` は deprecated alias として残るため、置換は段階的で問題ありません。CLI 検索置換で一括変換可能。
+- **`npx expo-codemod sdk-56-expo-router-react-navigation-replace src` の実行**: `@react-navigation/*` の直接 import を `expo-router/*` のエントリーポイントに自動書き換え。本プロジェクトでは現状直接 import がないため、影響は限定的です。
+- **`ExperimentalStack` への移行検討（opt-in）**: SDK 56 で追加された `react-native-screens/experimental` ベースの新 Stack。同じ Composition components が使えるため、置換コストは低い見込み。
+
+### `Stack.Toolbar` の導入検討
+
+ヘッダーボタンや bottom toolbar が必要になった場合、`Stack.Toolbar` を画面ファイル側に追加します（layout 側では bottom toolbar は使用不可）。iOS は SDK 55+、Android は SDK 56+ で alpha 提供。


### PR DESCRIPTION
## 概要

Expo Router の画面 `title` 宣言を `_layout.tsx` の `<Stack.Screen options>` (Options-based API) から各画面ファイル内の `<Stack.Screen.Title>` (Composition components API) に移行する。`presentation` 等の構造的設定は引き続き `_layout.tsx` 側に残す hybrid 構成。あわせて方針ドキュメント `docs/expo-router/screen-options.md` を追加。

## 背景・動機

Expo SDK 56 の方向性として Composition components API への継続投資が観測される。

- SDK 56.0.0 changelog で `Stack.Screen.Title` を `Stack.Title` にリネーム（旧名は deprecated alias として保持）。廃止ではなく整理対象として投資されている
- `Stack.Toolbar` の bottom toolbar は "can only be used inside page components, not in layout files" と公式明記。新機能は画面ファイル前提のアーキテクチャ
- `asChild` プロパティ等 Radix UI 風 modern composition パターンを採用

SDK 56 でも runtime API は無変更のため強制移行ではないが、CLAUDE.md の「ディレクトリ構造は機能で分類し co-location を採用する」と整合するため、将来の `Stack.Toolbar` 等の採用に向けた地ならしを兼ねて先行して方針統一する。

## アプローチ

採用方針:

| 種類 | 配置 |
|------|------|
| 画面個別の `title` | 画面ファイル内の `<Stack.Screen.Title>` |
| `presentation`, `sheetGrabberVisible`, `headerShown` 等の構造的設定 | `_layout.tsx` の `<Stack.Screen options>` |
| 共通ヘッダースタイル | `<Stack screenOptions={buildStackScreenOptions(...)}>` |

i18n は既存の `_layout.tsx` と同じ `useLingui()` + テンプレートリテラルパターン。

却下した代替案:

- **完全 co-location**: `presentation` は親 Stack が画面マウント前に把握する必要があり、画面ファイル側の `<Stack.Screen options>` では間に合わない（[expo/router#630](https://redirect.github.com/expo/router/issues/630) で EvanBacon 明言）
- **ファイルレベル options export** (`export const options` 等): Expo Router に該当 API は存在しない（`unstable_settings` は `initialRouteName` / `anchor` 専用）
- **`<Stack.Screen.Title asChild><Trans>...</Trans>`**: ネイティブ Title API は string children を想定しており未保証

実装中に判明した回帰と修正:

- 初期実装で root `_layout.tsx` の `<Stack.Screen name="(tabs)">` から `` title: t`ホーム` `` を削除したところ、`(tabs)` 配下から `/navigation-patterns` へ push した際の戻るボタンラベルが「(tabs)」（screen name フォールバック）になる回帰が発生
- 修正: `(tabs)/_layout.tsx` 側（これが `(tabs)` ルートの screen component）に `` <Stack.Screen.Title>{t`ホーム`}</Stack.Screen.Title> `` を配置。Options-based API への部分回帰を避けつつ Composition components 流で復元

ドキュメント:

- 新規 `docs/expo-router/screen-options.md`: 方針概要、使い分けルール、採用根拠、コードサンプル、アンチパターン、SDK 56 アップグレードメモ
- ローカル CLAUDE.md（gitignore 対象）の「重要な技術的決定事項」セクションに本ドキュメントへの参照を追記

## レビューポイント

1. hybrid 構成（title は画面側、presentation 等は layout 側）の方針自体が許容できるか
2. `(tabs)/_layout.tsx` 内に `<Stack.Screen.Title>` を置いて親 Stack の `(tabs)` エントリの title を設定するアプローチの妥当性（NativeTabs を内包するレイアウトファイル経由で親 Stack に注入する形）
3. SDK 56 移行時の API 名置換（`Stack.Screen.Title` → `Stack.Title`）を後続タスクとする扱い（deprecated alias で動作するため緊急性なし）

## 検証

- ✅ `pnpm -r run typecheck`
- ✅ `pnpm -r run lint`（oxlint / expo lint / oxfmt）
- ✅ `pnpm -r run lingui:extract`（44 メッセージ、Missing 0）
- ⚠️ 実機 / Simulator での動作確認は未実施。マージ前に以下を要確認:
  - 各画面のヘッダー title 表示
  - modal-screen / form-sheet-screen の presentation 挙動と grabber
  - `/navigation-patterns` 等への push 時の戻るボタンラベルが「ホーム」
  - ライト/ダーク テーマ切替後のヘッダースタイル
  - i18n 切替（ja / en）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
