### PR TITLE
[feat] presentation 値ごとの中間ページ（on-root / in-tab 選択画面）を追加

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/card/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/card/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function CardIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    // on root 版は #113 で追加する
+    // {
+    //   href: "/navigation-patterns/card/on-root",
+    //   text: <Trans>on root</Trans>,
+    // },
+    {
+      href: "/navigation-patterns/card/in-tab",
+      text: <Trans>in tab</Trans>,
+    },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`card`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/contained-modal/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/contained-modal/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function ContainedModalIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    // on root 版は #113 で追加する
+    // {
+    //   href: "/navigation-patterns/contained-modal/on-root",
+    //   text: <Trans>on root</Trans>,
+    // },
+    {
+      href: "/navigation-patterns/contained-modal/in-tab",
+      text: <Trans>in tab</Trans>,
+    },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`containedModal`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function ContainedTransparentModalIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    // on root 版は #113 で追加する
+    // {
+    //   href: "/navigation-patterns/contained-transparent-modal/on-root",
+    //   text: <Trans>on root</Trans>,
+    // },
+    {
+      href: "/navigation-patterns/contained-transparent-modal/in-tab",
+      text: <Trans>in tab</Trans>,
+    },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`containedTransparentModal`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function FormSheetIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    {
+      href: "/navigation-patterns/form-sheet/on-root",
+      text: <Trans>on root</Trans>,
+    },
+    // in tab 版は #114 で追加する
+    // {
+    //   href: "/navigation-patterns/form-sheet/in-tab",
+    //   text: <Trans>in tab</Trans>,
+    // },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`formSheet`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/full-screen-modal/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/full-screen-modal/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function FullScreenModalIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    {
+      href: "/navigation-patterns/full-screen-modal/on-root",
+      text: <Trans>on root</Trans>,
+    },
+    // in tab 版は #114 で追加する
+    // {
+    //   href: "/navigation-patterns/full-screen-modal/in-tab",
+    //   text: <Trans>in tab</Trans>,
+    // },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`fullScreenModal`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/index.tsx
@@ -6,31 +6,31 @@ export default function NavigationPatterns() {
   const { t } = useLingui();
   const list = [
     {
-      href: "/navigation-patterns/card/in-tab",
+      href: "/navigation-patterns/card",
       text: <Trans>card (push)</Trans>,
     },
     {
-      href: "/navigation-patterns/modal/on-root",
+      href: "/navigation-patterns/modal",
       text: <Trans>modal</Trans>,
     },
     {
-      href: "/navigation-patterns/transparent-modal/on-root",
+      href: "/navigation-patterns/transparent-modal",
       text: <Trans>transparentModal</Trans>,
     },
     {
-      href: "/navigation-patterns/contained-modal/in-tab",
+      href: "/navigation-patterns/contained-modal",
       text: <Trans>containedModal</Trans>,
     },
     {
-      href: "/navigation-patterns/contained-transparent-modal/in-tab",
+      href: "/navigation-patterns/contained-transparent-modal",
       text: <Trans>containedTransparentModal</Trans>,
     },
     {
-      href: "/navigation-patterns/full-screen-modal/on-root",
+      href: "/navigation-patterns/full-screen-modal",
       text: <Trans>fullScreenModal</Trans>,
     },
     {
-      href: "/navigation-patterns/form-sheet/on-root",
+      href: "/navigation-patterns/form-sheet",
       text: <Trans>formSheet</Trans>,
     },
   ] as const satisfies LinkItem[];

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/modal/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/modal/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function ModalIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    {
+      href: "/navigation-patterns/modal/on-root",
+      text: <Trans>on root</Trans>,
+    },
+    // in tab 版は #114 で追加する
+    // {
+    //   href: "/navigation-patterns/modal/in-tab",
+    //   text: <Trans>in tab</Trans>,
+    // },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`modal`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/transparent-modal/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/transparent-modal/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { LinkList, type LinkItem } from "../../../../../components/link-list/LinkList";
+
+export default function TransparentModalIntermediate(): ReactElement {
+  const { t } = useLingui();
+  const list = [
+    {
+      href: "/navigation-patterns/transparent-modal/on-root",
+      text: <Trans>on root</Trans>,
+    },
+    // in tab 版は #114 で追加する
+    // {
+    //   href: "/navigation-patterns/transparent-modal/in-tab",
+    //   text: <Trans>in tab</Trans>,
+    // },
+  ] as const satisfies LinkItem[];
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`transparentModal`}</Stack.Screen.Title>
+      <LinkList data={list} />
+    </>
+  );
+}

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -26,6 +26,7 @@ msgid "BottomSheetBehavior で表示される。detent は最大 3 つまで。s
 msgstr "Presented with BottomSheetBehavior. Limited to up to 3 detents. `sheetGrabberVisible` is ignored; Android-only options such as `sheetElevation` apply instead."
 
 #: src/app/(tabs)/(home)/navigation-patterns/card/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/card/index.tsx:22
 msgid "card"
 msgstr "card"
 
@@ -34,11 +35,13 @@ msgid "card (push)"
 msgstr "card (push)"
 
 #: src/app/(tabs)/(home)/navigation-patterns/contained-modal/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/contained-modal/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:22
 msgid "containedModal"
 msgstr "containedModal"
 
 #: src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:26
 msgid "containedTransparentModal"
 msgstr "containedTransparentModal"
@@ -51,15 +54,23 @@ msgstr "Modal on the current context"
 msgid "current context 上の透過 modal"
 msgstr "Transparent modal on the current context"
 
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:34
 #: src/app/navigation-patterns/form-sheet/on-root.tsx:11
 msgid "formSheet"
 msgstr "formSheet"
 
+#: src/app/(tabs)/(home)/navigation-patterns/full-screen-modal/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:30
 #: src/app/navigation-patterns/full-screen-modal/on-root.tsx:11
 msgid "fullScreenModal"
 msgstr "fullScreenModal"
+
+#: src/app/(tabs)/(home)/navigation-patterns/card/index.tsx:16
+#: src/app/(tabs)/(home)/navigation-patterns/contained-modal/index.tsx:16
+#: src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/index.tsx:16
+msgid "in tab"
+msgstr "in tab"
 
 #: src/app/(tabs)/(home)/navigation-patterns/contained-modal/in-tab.tsx:34
 msgid "iOS では「閉じる」ボタンが必須 (swipe down は効かない)。Android では戻る操作でも閉じる。"
@@ -74,9 +85,17 @@ msgid "iOS の挙動"
 msgstr "iOS behavior"
 
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:14
+#: src/app/(tabs)/(home)/navigation-patterns/modal/index.tsx:22
 #: src/app/navigation-patterns/modal/on-root.tsx:11
 msgid "modal"
 msgstr "modal"
+
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/full-screen-modal/index.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/modal/index.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/transparent-modal/index.tsx:11
+msgid "on root"
+msgstr "on root"
 
 #: src/app/(tabs)/(home)/navigation-patterns/card/in-tab.tsx:22
 msgid "OS / テーマに応じたスライドアニメーションで push される。システムの戻るボタン / ジェスチャーで戻れる。"
@@ -91,6 +110,7 @@ msgid "swipe で閉じられない全画面モーダル"
 msgstr "Full-screen modal that cannot be dismissed by swipe"
 
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:18
+#: src/app/(tabs)/(home)/navigation-patterns/transparent-modal/index.tsx:22
 #: src/app/navigation-patterns/transparent-modal/on-root.tsx:11
 msgid "transparentModal"
 msgstr "transparentModal"

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -26,6 +26,7 @@ msgid "BottomSheetBehavior で表示される。detent は最大 3 つまで。s
 msgstr "BottomSheetBehavior で表示される。detent は最大 3 つまで。sheetGrabberVisible は無視され、代わりに sheetElevation 等の Android 専用オプションがある。"
 
 #: src/app/(tabs)/(home)/navigation-patterns/card/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/card/index.tsx:22
 msgid "card"
 msgstr "card"
 
@@ -34,11 +35,13 @@ msgid "card (push)"
 msgstr "card (push)"
 
 #: src/app/(tabs)/(home)/navigation-patterns/contained-modal/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/contained-modal/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:22
 msgid "containedModal"
 msgstr "containedModal"
 
 #: src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:26
 msgid "containedTransparentModal"
 msgstr "containedTransparentModal"
@@ -51,15 +54,23 @@ msgstr "current context 上の modal"
 msgid "current context 上の透過 modal"
 msgstr "current context 上の透過 modal"
 
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:34
 #: src/app/navigation-patterns/form-sheet/on-root.tsx:11
 msgid "formSheet"
 msgstr "formSheet"
 
+#: src/app/(tabs)/(home)/navigation-patterns/full-screen-modal/index.tsx:22
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:30
 #: src/app/navigation-patterns/full-screen-modal/on-root.tsx:11
 msgid "fullScreenModal"
 msgstr "fullScreenModal"
+
+#: src/app/(tabs)/(home)/navigation-patterns/card/index.tsx:16
+#: src/app/(tabs)/(home)/navigation-patterns/contained-modal/index.tsx:16
+#: src/app/(tabs)/(home)/navigation-patterns/contained-transparent-modal/index.tsx:16
+msgid "in tab"
+msgstr "in tab"
 
 #: src/app/(tabs)/(home)/navigation-patterns/contained-modal/in-tab.tsx:34
 msgid "iOS では「閉じる」ボタンが必須 (swipe down は効かない)。Android では戻る操作でも閉じる。"
@@ -74,9 +85,17 @@ msgid "iOS の挙動"
 msgstr "iOS の挙動"
 
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:14
+#: src/app/(tabs)/(home)/navigation-patterns/modal/index.tsx:22
 #: src/app/navigation-patterns/modal/on-root.tsx:11
 msgid "modal"
 msgstr "modal"
+
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/full-screen-modal/index.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/modal/index.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/transparent-modal/index.tsx:11
+msgid "on root"
+msgstr "on root"
 
 #: src/app/(tabs)/(home)/navigation-patterns/card/in-tab.tsx:22
 msgid "OS / テーマに応じたスライドアニメーションで push される。システムの戻るボタン / ジェスチャーで戻れる。"
@@ -91,6 +110,7 @@ msgid "swipe で閉じられない全画面モーダル"
 msgstr "swipe で閉じられない全画面モーダル"
 
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:18
+#: src/app/(tabs)/(home)/navigation-patterns/transparent-modal/index.tsx:22
 #: src/app/navigation-patterns/transparent-modal/on-root.tsx:11
 msgid "transparentModal"
 msgstr "transparentModal"


### PR DESCRIPTION
## Summary

- `(tabs)/(home)/navigation-patterns/<value>/index.tsx` を 7 個新規作成。LinkList で `on root` / `in tab` 2 リンクを提示
- 一覧画面の href を中間ページ URL に変更（リンクラベルは既存維持）
- 現時点では片側のサンプルしか存在しないため、不足側のリンクはコメントアウト（#113 / #114 で有効化）
- en の messages.po に `on root` / `in tab` の英訳を追加

Sub-issue of #110, resolves #112. Depends on #111 (already merged).

## Test plan

- [x] `pnpm -r run generate-types`
- [x] `pnpm -r run typecheck`
- [x] `pnpm -r run lingui:extract`（新規 msgid の英訳を追加済み）
- [x] `pnpm -r run lint`
- [ ] 一覧 → 中間ページ → 既存サンプルへ到達できることを実機で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)