### PR TITLE
ci: eas-build を手動実行のみに変更

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,9 +1,6 @@
 name: eas-build
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 概要

`.github/workflows/eas-build.yml` の `on.push.branches: [main]` トリガーを削除し、`workflow_dispatch` のみで起動するようにする。

## 背景・動機

EAS Build の Free プランは月間 30 ビルドが上限。現状は main への push (PR マージ) ごとに Android development ビルドが走るため、PR マージのたびにビルド枠を消費し、容易に上限へ到達してしまう。実際に今月分の枠は既に使い切ってしまった。

ネイティブビルドが本当に必要になるのは、ネイティブモジュールの追加や Expo SDK のアップグレードなど限られたタイミングだけなので、自動実行をやめて必要なときだけ手動で回す運用に切り替える。

## アプローチ

- `on:` から `push.branches: [main]` ブロックを削除し、`workflow_dispatch` のみ残す
- jobs 以下のビルド内容 (`eas build --profile development --platform android --non-interactive`) はそのまま流用し、手動トリガー時の挙動は変更しない
- EAS Update (`eas-update.yml` / `preview.yml`) はビルド枠とは別枠 (月 1,000 update 無料) のため本 PR のスコープからは外し、従来どおり main push / PR イベントで自動実行する

## レビューポイント

- 手動実行運用への切り替えで問題がないか (= 自動 development ビルドが止まることで困るフローがないか)
- EAS Update 側の自動実行は維持する方針で問題ないか