### PR TITLE
docs: CLAUDE.md を git 管理化し内容を整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-CLAUDE.md
 .claude/settings.local.json
 
 # Logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+## 前提
+
+Expo SDK 55 monorepo。詳細は `apps/sandbox/package.json` と `apps/sandbox/app.json` を参照。
+
+## Conventions
+
+### パッケージマネージャ
+
+- **pnpm のみを使用**。npm / yarn / corepack は使わない
+  - pnpm のバージョンは `package.json` の `packageManager` フィールドで固定。`corepack enable` / `corepack prepare` 等は実行しないこと
+- 実行はルートから:
+  - 全ワークスペース横断: `pnpm -r run <script>`
+  - 特定パッケージ: `pnpm --dir apps/sandbox <command>`
+- **Expo SDK パッケージの追加は `pnpm --dir apps/sandbox exec expo install <pkg>`**（npx / pnpm dlx は使わない。SDK 互換バージョンを自動解決）
+
+### TypeScript
+
+- **Type Assertion は原則使わない**
+
+### ファイル配置
+
+- **機能で分類し co-location**: 関連する component / hooks / utils は同じ機能ディレクトリにまとめる
+- **barrel file は作らない**
+- **`docs/` と `tasks/` を混在させない**
+  - `docs/`: 長期的に参照する設計ドキュメント・運用手順
+  - `tasks/`: 後続タスクの引き継ぎ資料・バックログ。完了後は削除/アーカイブ
+
+## Commands
+
+### 開発サーバー
+
+- `pnpm --dir apps/sandbox start` — Metro 起動
+- `pnpm --dir apps/sandbox run ios` / `android` / `web`
+
+### コード品質
+
+- `pnpm -r run lint` — 3 層リント（詳細: [`docs/lint.md`](docs/lint.md)）
+- `pnpm -r run format` — フォーマット
+- `pnpm -r run typecheck` — 型チェック（`generate-types` 込み）
+
+### 国際化
+
+- `pnpm -r run lingui:extract` — UI テキストやファイル位置を変えた場合に実行
+  - 詳細・運用は [`docs/lingui/workflow.md`](docs/lingui/workflow.md)。CI（`lingui-check.yml`）でも同期チェックされる

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -1,0 +1,19 @@
+# リント構成
+
+`pnpm -r run lint` は内部で oxlint → expo lint → oxfmt の順に 3 層リントを走らせる。重複なくチェックするのが設計の意図。
+
+## 各層の役割
+
+1. **oxlint**（`--type-aware --type-check`）
+   - Rust ベースの高速リンタ
+   - tsgolint 経由で TypeScript 型エラーも同時検出
+   - `typecheck` スクリプトはこれを再利用している
+
+2. **expo lint**
+   - `eslint-config-expo` ベース
+   - `eslint-plugin-oxlint` で oxlint と重複するルールは自動無効化
+
+3. **oxfmt**
+   - Prettier 互換の高速フォーマッタ
+
+スクリプト定義は `apps/sandbox/package.json` を参照。


### PR DESCRIPTION
## 概要

これまで個人設定的に運用していた CLAUDE.md を共有資産として git 管理に切り替える。合わせて Claude Code が毎ターン自動ロードする特性を踏まえ、コンテキスト圧迫を避けるため内容を見直した。

## 背景・動機

- CLAUDE.md は Claude Code が会話開始時に毎回ロードするため、肥大化するとトークン消費が増える
- 旧 CLAUDE.md は `package.json` scripts や `tsconfig.json` の設定をコピペで重複保持しており、二重メンテになりがち
- 旧記述には事実誤り（`app.config.js` に `newArchEnabled: true` と記載していたが、実体は `app.json` で SDK 55 のデフォルト有効）も含まれていた

## アプローチ

「コードから読めば分かる情報は CLAUDE.md に書かない」を基準に再構成:

- `.gitignore` から CLAUDE.md の行を削除して追跡対象に
- **削除した情報**: ディレクトリ構造図、開発コマンド一覧、tsconfig の strict 設定列挙、テーマ実装の詳細、CI ワークフローの存在 等
- **残す基準**: 設計意図 / 非自明な運用ルール / docs/ への入り口
- 構成を **Conventions（規約）/ Commands（コマンドカタログ）** の 2 軸に整理
- リント 3 層構成の解説は参照頻度が低いため `docs/lint.md` に外出し
- 上記の誤記述を是正

結果: 約 130 行 → 46 行に圧縮。

## レビューポイント

- CLAUDE.md に残した項目の取捨選択（特に「Type Assertion 原則禁止」だけを残した TypeScript セクションなど）
- `docs/lint.md` への外出し範囲が妥当か
- 圧縮しすぎて必要な情報まで削っていないか