### PR TITLE
fix: transparentModal オーバーレイ内 ScrollView のジェスチャ競合を解消

### DIFF
--- a/apps/sandbox/src/components/presentation-sample/PresentationSampleOverlay.tsx
+++ b/apps/sandbox/src/components/presentation-sample/PresentationSampleOverlay.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { Pressable, ScrollView, StyleSheet } from "react-native";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { useRouter } from "expo-router";
 import { Spacing } from "../../constants/theme";
 import { useTheme } from "../../theme/useTheme";
@@ -16,16 +16,16 @@ export function PresentationSampleOverlay(props: PresentationSampleOverlayProps)
   };
 
   return (
-    <Pressable style={styles.backdrop} onPress={close}>
-      <Pressable
+    <View style={styles.backdrop}>
+      <Pressable style={StyleSheet.absoluteFill} onPress={close} />
+      <View
         style={[styles.card, { backgroundColor: colors.background, borderColor: colors.border }]}
-        onPress={() => {}}
       >
         <ScrollView contentContainerStyle={styles.cardScroll}>
           <PresentationSampleBody {...props} />
         </ScrollView>
-      </Pressable>
-    </Pressable>
+      </View>
+    </View>
   );
 }
 


### PR DESCRIPTION
## Summary

- `PresentationSampleOverlay` の Pressable ネスト構造が ScrollView から touch responder を奪い、オーバーレイ内のスクロールが効かない問題 (#131) を兄弟配置パターンで修正
- backdrop は通常の `View` にし、close タップ判定を `StyleSheet.absoluteFill` の `Pressable` に分離。card は no-op `onPress` を持つ `Pressable` から通常の `View` に戻した
- 共通コンポーネントの修正なので transparentModal / containedTransparentModal の in-tab / on-root 計 4 サンプルすべてに改善が波及する

## Test plan

実機 iOS / Android で以下 4 サンプルを開き、それぞれ確認:

- [ ] `transparentModal` (in-tab) ← 主シナリオ。card 内を上下スワイプで ScrollView がスクロールすること
- [ ] `containedTransparentModal` (in-tab)
- [ ] `transparentModal` (on-root)
- [ ] `containedTransparentModal` (on-root)

各画面共通の確認項目:

- [ ] card 外 (上下のスキマ) をタップ → 閉じること
- [ ] card 内の余白部分をタップ → 閉じないこと
- [ ] 「閉じる」ボタンタップ → 閉じること
- [ ] Android: 戻るボタンで閉じること

Closes #131