### PR TITLE
chore: CLAUDE.md の規約 2 件を oxlint で機械化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,9 @@ Expo SDK 55 monorepo。詳細は `apps/sandbox/package.json` と `apps/sandbox/a
   - 特定パッケージ: `pnpm --dir apps/sandbox <command>`
 - **Expo SDK パッケージの追加は `pnpm --dir apps/sandbox exec expo install <pkg>`**（npx / pnpm dlx は使わない。SDK 互換バージョンを自動解決）
 
-### TypeScript
-
-- **Type Assertion は原則使わない**
-
 ### ファイル配置
 
 - **機能で分類し co-location**: 関連する component / hooks / utils は同じ機能ディレクトリにまとめる
-- **barrel file は作らない**
 - **`docs/` と `tasks/` を混在させない**
   - `docs/`: 長期的に参照する設計ドキュメント・運用手順
   - `tasks/`: 後続タスクの引き継ぎ資料・バックログ。完了後は削除/アーカイブ

--- a/apps/sandbox/.oxlintrc.json
+++ b/apps/sandbox/.oxlintrc.json
@@ -1,9 +1,12 @@
 {
-  "plugins": null,
+  "plugins": ["eslint", "unicorn", "typescript", "oxc", "import"],
   "categories": {
     "correctness": "error"
   },
-  "rules": {},
+  "rules": {
+    "typescript/no-unsafe-type-assertion": "error",
+    "oxc/no-barrel-file": ["error", { "threshold": 1 }]
+  },
   "settings": {
     "jsx-a11y": {
       "polymorphicPropName": null,

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -8,6 +8,9 @@
    - Rust ベースの高速リンタ
    - tsgolint 経由で TypeScript 型エラーも同時検出
    - `typecheck` スクリプトはこれを再利用している
+   - プロジェクト固有のルール（`apps/sandbox/.oxlintrc.json`）:
+     - `typescript/no-unsafe-type-assertion`: 型安全性を損なう narrowing assertion を禁止（`as const` / broadening は許容）
+     - `oxc/no-barrel-file`（threshold: 1）: `export * from "..."` 形式の barrel file を禁止（背景は [`no-barrel-file.md`](no-barrel-file.md)）
 
 2. **expo lint**
    - `eslint-config-expo` ベース

--- a/docs/no-barrel-file.md
+++ b/docs/no-barrel-file.md
@@ -1,0 +1,71 @@
+# barrel file を避ける
+
+「barrel file」とは、ディレクトリ内の複数モジュールをまとめて再エクスポートする `index.ts` などのファイル。本リポジトリでは原則として作成・利用しない。
+
+```ts
+// features/button/index.ts (barrel file の例)
+export * from "./Button";
+export * from "./useButton";
+export { ButtonGroup } from "./ButtonGroup";
+```
+
+## 理由
+
+### 1. バンドルサイズ・起動コスト
+
+barrel から import すると、実際に使うのが一部であっても **解決時に barrel が参照するモジュールツリー全体が読み込まれる**。tree-shaking が効くケースでも、解析・パースのコストは発生する。
+
+```ts
+// Button だけ使いたいのに features/button/* 全体がロードされる
+import { Button } from "@/features/button";
+```
+
+Next.js などで barrel パターンが起動遅延の主因になった事例: [Speeding up the JavaScript ecosystem - The barrel file debacle](https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-7)
+
+### 2. ES Modules はディレクトリインポートをサポートしない
+
+CommonJS では `import { foo } from "./utils"` が `./utils/index.js` に解決されたが、**ES Modules 仕様では明示的なファイル指定が必要**。
+
+```ts
+// CommonJS や bundler 経由でしか動かない（ESM 仕様としては invalid）
+import { foo } from "./utils";
+
+// ES Modules 仕様準拠
+import { foo } from "./utils/index.js";
+import { foo } from "./utils/foo.js";
+```
+
+Metro / TypeScript 等の bundler・解決層がディレクトリ → `index.ts` の補完をしているため気にせず動いてしまうが、barrel file の利便性の前提だった「ディレクトリ単位の import」は標準的な書き方ではなくなった。素直に対象ファイルを直接 import する方が ESM 寄りで明快。
+
+### 3. 循環参照のリスク
+
+機能ディレクトリの `index.ts` から再エクスポートすると、同ディレクトリ内のファイルが barrel 経由で互いを参照したときに循環参照が発生しやすい。直接 import なら依存方向が明示される。
+
+### 4. ナビゲーションと検索の摩擦
+
+エディタの「定義へ移動」が barrel に着地して二重ジャンプが必要になる、`grep` で実装ファイルへの直接参照が見えづらい、といった日常的な不便も生じる。
+
+## このプロジェクトでの強制
+
+[`oxc/no-barrel-file`](https://oxc.rs/docs/guide/usage/linter/rules/oxc/no-barrel-file) を `threshold: 1` で有効化している（[`apps/sandbox/.oxlintrc.json`](../apps/sandbox/.oxlintrc.json)）。
+
+- 検出されるパターン: `export * from "..."` 形式の barrel
+  - threshold は「barrel から推移的にロードされるモジュール総数」の上限値（詳細は [`docs/lint.md`](lint.md)）
+- 検出されないパターン（人間判断で避ける）:
+  - `export { X } from "..."` 形式の named re-export
+  - barrel 経由の import（消費側）
+
+## どう書くか
+
+barrel を作らず、必要なものを直接 import する。
+
+```ts
+// NG
+import { Button, useButton } from "@/features/button";
+
+// OK
+import { Button } from "@/features/button/Button";
+import { useButton } from "@/features/button/useButton";
+```
+
+外部公開する API（npm パッケージのエントリポイント等）は barrel の合理性が残るが、本リポジトリはアプリケーションコードのみのため対象外。


### PR DESCRIPTION
## 概要

CLAUDE.md に書いていた 2 つの規約を oxlint ルールに置き換え、コンテキスト負荷の軽減と規約の実効性向上を狙う。

- Type Assertion を原則使わない → `typescript/no-unsafe-type-assertion`
- barrel file は作らない → `oxc/no-barrel-file` (threshold: 1)

## 背景・動機

CLAUDE.md に並べていた規約のうち、機械的に検証可能なものを Linter で強制すれば毎ターンのコンテキストに載せる必要がなく、人間の規約遵守判断にも依存しなくなる。本リポジトリの 3 層リント (oxlint → expo lint → oxfmt) の oxlint 層に追加した。

## アプローチ

### Type Assertion: `no-unsafe-type-assertion` を採用

候補は 2 つあった:

- `typescript/consistent-type-assertions` (`assertionStyle: never`): `as Foo` を一律禁止
- `typescript/no-unsafe-type-assertion`: 型安全性を損なう narrowing assertion のみ禁止 (broadening と `as const` は許容)

「型安全性を損なうものを禁止したい」という意図に合致する後者を採用。プロジェクトは既に `oxlint --type-aware --type-check` 運用のため type-aware 要件も満たす。

### barrel file: `oxc/no-barrel-file` で部分機械化

oxlint の `oxc/no-barrel-file` は `export * from "..."` 形式のみ検出する。`export { X } from "..."` 形式の named re-export や barrel 経由の import を含めて完全機械化するには ESLint プラグインの併用が必要だが、運用一貫性を優先し oxlint で拾える範囲のみ強制とした。

`threshold: 1` で、ターゲットが 1 モジュール以上の依存を持つ `export *` を実質全面禁止。`threshold: 0` はバグ ([oxc#16435](https://redirect.github.com/oxc-project/oxc/issues/16435)) があり避けた。

### `import` プラグインを明示有効化

`oxc/no-barrel-file` は推移的に読み込まれるモジュール数をカウントするため、モジュール解決を行う `import` プラグインが必要 (公式ドキュメントには未記載だが、ルールのソースコード [`no_barrel_file.rs`](https://redirect.github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs) で `module_record.get_loaded_module()` を参照していることから判明)。`.oxlintrc.json` の `plugins` で明示的に有効化し、ついでにデフォルト ON のプラグイン (`eslint`, `unicorn`, `typescript`, `oxc`) も併記して設定を自己文書化した。

### ドキュメント整理

- 機械化済みの行は CLAUDE.md から削除
- barrel file を避ける理由 (バンドルコスト / ESM のディレクトリインポート非対応 / 循環参照 / ナビゲーション摩擦) は `docs/no-barrel-file.md` に新設
- `docs/lint.md` にプロジェクト固有ルールを追記し、背景ドキュメントへリンク

## レビューポイント

- 機械化済み項目を CLAUDE.md から完全に削除した判断 (人間が読む場所からは消える)
- `threshold: 1` の運用感 (依存ゼロのリーフモジュールの `export *` のみ抜けるが実用上は十分という前提)
- `plugins` 配列の自己文書化方針 (`eslint` を含めるなど)

🤖 Generated with [Claude Code](https://claude.com/claude-code)