### PR TITLE
chore: typecheck を lint:oxlint に統合し重複を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
 
-      - name: Generate typed routes
-        run: pnpm -r run generate-types
-
       - name: Run Oxlint
         run: pnpm -r run lint:oxlint --format=github
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,8 @@ Expo SDK 55 monorepo。詳細は `apps/sandbox/package.json` と `apps/sandbox/a
 
 ### コード品質
 
-- `pnpm -r run lint` — 3 層リント（詳細: [`docs/lint.md`](docs/lint.md)）
+- `pnpm -r run lint` — 3 層リント（詳細: [`docs/lint.md`](docs/lint.md)）。`lint:oxlint` が `generate-types` と型チェックを内包する
 - `pnpm -r run format` — フォーマット
-- `pnpm -r run typecheck` — 型チェック（`generate-types` 込み）
 
 ### 国際化
 

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -10,12 +10,11 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "pnpm run lint:oxlint && pnpm run lint:expo && pnpm run lint:oxfmt",
-    "lint:oxlint": "oxlint --type-aware --type-check",
+    "lint:oxlint": "pnpm run generate-types && oxlint --type-aware --type-check",
     "lint:expo": "expo lint",
     "lint:oxfmt": "oxfmt . --check",
     "format": "oxfmt . --write",
     "generate-types": "expo customize tsconfig.json",
-    "typecheck": "pnpm run generate-types && oxlint --type-aware --type-check",
     "lingui:extract": "lingui extract --clean"
   },
   "dependencies": {

--- a/docs/lint.md
+++ b/docs/lint.md
@@ -6,8 +6,8 @@
 
 1. **oxlint**（`--type-aware --type-check`）
    - Rust ベースの高速リンタ
-   - tsgolint 経由で TypeScript 型エラーも同時検出
-   - `typecheck` スクリプトはこれを再利用している
+   - tsgolint 経由で TypeScript 型エラーも同時検出（`tsc --noEmit` 相当を兼ねる）
+   - 先頭で `generate-types`（`expo customize tsconfig.json`）を実行し Typed Routes の型定義を最新化する
    - プロジェクト固有のルール（`apps/sandbox/.oxlintrc.json`）:
      - `typescript/no-unsafe-type-assertion`: 型安全性を損なう narrowing assertion を禁止（`as const` / broadening は許容）
      - `oxc/no-barrel-file`（threshold: 1）: `export * from "..."` 形式の barrel file を禁止（背景は [`no-barrel-file.md`](no-barrel-file.md)）


### PR DESCRIPTION
## 概要

`apps/sandbox/package.json` の `lint:oxlint` と `typecheck` のコマンド本体が同一になっていたため、`typecheck` を削除し、`lint:oxlint` の先頭に `generate-types` を組み込んで一本化した。CI からも独立した `Generate typed routes` ステップを削除している。

## 背景・動機

`lint:oxlint` と `typecheck` は、それぞれ独立して導入された後、2026-02-24 の 620e253「build: oxlint の Type Checking を導入し tsc --noEmit を置き換え」で `tsc --noEmit` を `oxlint --type-aware --type-check` に切り替えた結果、コマンド本体が一致してしまっていた。両者の差分は `typecheck` が先頭で `generate-types` を実行する点のみで、同じコマンドが 2 箇所で定義される DRY 違反の状態だった。さらに `lint:oxlint` を単独で実行した場合、`.expo/types`（Typed Routes）が古ければ型チェック結果が不正確になり得るという暗黙の前提もあった。

## アプローチ

- `typecheck` を削除し、`lint:oxlint` を `pnpm run generate-types && oxlint --type-aware --type-check` に変更
- CI の `Generate typed routes` ステップを削除（`lint:oxlint` 側に内包されるため）
- `CLAUDE.md` / `docs/lint.md` の記述を更新

### 検討した代替案

- **`lint` スクリプトの先頭に `generate-types` を移す案**: `lint:oxlint` 単独実行ではオーバーヘッドが入らない利点があるが、`lint:oxlint` を直接叩いた際に古い `.expo/types` で型チェックが行われるリスクが残る。安全側に倒して棄却
- **`tsc --noEmit` を `typecheck` に戻す案**: `oxlint --type-check` は experimental ステータスだが、本リポジトリは sandbox 1 パッケージ規模で typescript-go のリスクシナリオに該当しないため、現状の置き換え方針を維持。`typescript` 依存と `tsconfig.json` は退避経路として温存している

## レビューポイント

- `lint:oxlint` の単独実行ごとに `expo customize tsconfig.json` が走るオーバーヘッド（実測で 400ms〜1.4s 程度）が許容できるか
- `tsc --noEmit` への退避経路を維持する方針で問題ないか