### PR TITLE
refactor(theme): デザイントークン整備と ThemedText 刷新

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/_layout.tsx
@@ -3,10 +3,10 @@ import { useTheme } from "../../../theme/useTheme";
 import { buildStackScreenOptions } from "../../../theme/navigationScreenOptions";
 
 export default function HomeLayout() {
-  const { colorScheme, colors } = useTheme();
+  const { colorScheme, tokens } = useTheme();
 
   return (
-    <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
+    <Stack screenOptions={buildStackScreenOptions(tokens.color, colorScheme)}>
       <Stack.Screen
         name="navigation-patterns/contained-modal/in-tab"
         options={{ presentation: "containedModal" }}

--- a/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/_layout.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../../../theme/useTheme";
 import { buildStackScreenOptions } from "../../../theme/navigationScreenOptions";
 
 export default function SettingsLayout() {
-  const { colorScheme, colors } = useTheme();
+  const { colorScheme, tokens } = useTheme();
 
-  return <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)} />;
+  return <Stack screenOptions={buildStackScreenOptions(tokens.color, colorScheme)} />;
 }

--- a/apps/sandbox/src/app/_layout.tsx
+++ b/apps/sandbox/src/app/_layout.tsx
@@ -21,12 +21,12 @@ import { initializeI18n } from "../i18n";
 initializeI18n();
 
 function RootLayoutContent() {
-  const { colorScheme, colors } = useTheme();
+  const { colorScheme, tokens } = useTheme();
 
   return (
     <>
       <StatusBar style={colorScheme === "dark" ? "light" : "dark"} />
-      <Stack screenOptions={buildStackScreenOptions(colors, colorScheme)}>
+      <Stack screenOptions={buildStackScreenOptions(tokens.color, colorScheme)}>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen
           name="navigation-patterns/modal/on-root"

--- a/apps/sandbox/src/components/link-list/LinkList.tsx
+++ b/apps/sandbox/src/components/link-list/LinkList.tsx
@@ -33,12 +33,7 @@ function LinkListItem({ href, text }: LinkItem): ReactElement {
 
   return (
     <Link href={href} asChild>
-      <Pressable
-        style={({ pressed }) => [
-          styles.item,
-          pressed ? { backgroundColor: tokens.color.background.pressed } : null,
-        ]}
-      >
+      <Pressable style={styles.item}>
         <ThemedText type="headline">{text}</ThemedText>
         <Ionicons name="chevron-forward" size={20} color={tokens.color.text.tertiary} />
       </Pressable>

--- a/apps/sandbox/src/components/link-list/LinkList.tsx
+++ b/apps/sandbox/src/components/link-list/LinkList.tsx
@@ -15,7 +15,7 @@ type LinkListProps = {
 };
 
 export function LinkList({ data }: LinkListProps): ReactElement {
-  const { colors } = useTheme();
+  const { tokens } = useTheme();
 
   return (
     <FlatList
@@ -23,19 +23,24 @@ export function LinkList({ data }: LinkListProps): ReactElement {
       renderItem={({ item }) => <LinkListItem {...item} />}
       keyExtractor={(item) => (typeof item.href === "string" ? item.href : item.href.pathname)}
       contentContainerStyle={styles.container}
-      style={{ backgroundColor: colors.background }}
+      style={{ backgroundColor: tokens.color.background.canvas }}
     />
   );
 }
 
 function LinkListItem({ href, text }: LinkItem): ReactElement {
-  const { colors } = useTheme();
+  const { tokens } = useTheme();
 
   return (
     <Link href={href} asChild>
-      <Pressable style={styles.item}>
-        <ThemedText type="subtitle">{text}</ThemedText>
-        <Ionicons name="chevron-forward" size={20} color={colors.text} />
+      <Pressable
+        style={({ pressed }) => [
+          styles.item,
+          pressed ? { backgroundColor: tokens.color.background.pressed } : null,
+        ]}
+      >
+        <ThemedText type="headline">{text}</ThemedText>
+        <Ionicons name="chevron-forward" size={20} color={tokens.color.text.tertiary} />
       </Pressable>
     </Link>
   );

--- a/apps/sandbox/src/components/themed-text/ThemedText.tsx
+++ b/apps/sandbox/src/components/themed-text/ThemedText.tsx
@@ -1,69 +1,98 @@
 import type { ReactElement } from "react";
-import { StyleSheet, Text, type TextProps, type TextStyle } from "react-native";
-import { Fonts, type ColorTokenName } from "../../constants/theme";
+import { Text, type TextProps, type TextStyle } from "react-native";
+import type { ColorTokenName } from "../../constants/theme";
 import { useTheme } from "../../theme/useTheme";
+import { Typography, type TypographyTokenName } from "../../theme/tokens/typography";
 
-export type ThemedTextType =
-  | "default"
-  | "title"
-  | "subtitle"
-  | "small"
-  | "smallBold"
-  | "link"
-  | "linkPrimary"
-  | "code";
+type LegacyThemedTextType = "default" | "subtitle" | "small" | "smallBold" | "link" | "linkPrimary";
+
+export type ThemedTextType = TypographyTokenName | LegacyThemedTextType;
+
+export type ThemedTextWeight = "regular" | "medium" | "semibold" | "bold";
+
+export type ThemedTextTone =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "disabled"
+  | "accent"
+  | "onAccent";
 
 export interface ThemedTextProps extends TextProps {
   type?: ThemedTextType;
+  weight?: ThemedTextWeight;
+  tone?: ThemedTextTone;
+  align?: TextStyle["textAlign"];
+  /** @deprecated tone を使うこと */
   themeColor?: ColorTokenName;
 }
 
-const typeStyles: Record<ThemedTextType, TextStyle> = StyleSheet.create({
-  default: {
-    fontSize: 16,
-    fontWeight: "400",
-    lineHeight: 24,
-  },
-  title: {
-    fontSize: 32,
-    fontWeight: "700",
-    lineHeight: 32,
-  },
-  subtitle: {
-    fontSize: 20,
-    fontWeight: "600",
-  },
-  small: {
-    fontSize: 14,
-    fontWeight: "400",
-  },
-  smallBold: {
-    fontSize: 14,
-    fontWeight: "600",
-  },
-  link: {
-    fontSize: 16,
-    fontWeight: "400",
-    textDecorationLine: "underline",
-  },
-  linkPrimary: {
-    fontSize: 16,
-    fontWeight: "600",
-    textDecorationLine: "underline",
-  },
-  code: {
-    fontSize: 14,
-    fontWeight: "400",
-    fontFamily: Fonts.mono,
-  },
-});
+const legacyTypeMap: Record<LegacyThemedTextType, TypographyTokenName> = {
+  default: "body",
+  subtitle: "headline",
+  small: "caption",
+  smallBold: "label",
+  link: "body",
+  linkPrimary: "bodyEmphasis",
+};
+
+const legacyDecoration: Partial<Record<LegacyThemedTextType, TextStyle>> = {
+  link: { textDecorationLine: "underline" },
+  linkPrimary: { textDecorationLine: "underline" },
+};
+
+const fontWeightMap: Record<ThemedTextWeight, NonNullable<TextStyle["fontWeight"]>> = {
+  regular: "400",
+  medium: "500",
+  semibold: "600",
+  bold: "700",
+};
+
+const isLegacy = (type: ThemedTextType): type is LegacyThemedTextType => type in legacyTypeMap;
+
+const warnedLegacyTypes = new Set<string>();
+const warnLegacyType = (type: LegacyThemedTextType, mapped: TypographyTokenName) => {
+  if (__DEV__ && !warnedLegacyTypes.has(type)) {
+    warnedLegacyTypes.add(type);
+    console.warn(
+      `[ThemedText] type="${type}" は deprecated。第2段で削除予定 (代替: type="${mapped}")`,
+    );
+  }
+};
 
 export function ThemedText({
-  type = "default",
-  themeColor = "text",
+  type = "body",
+  weight,
+  tone = "primary",
+  align,
+  themeColor,
   style,
   ...rest
 }: ThemedTextProps): ReactElement {
-  const { colors } = useTheme();
-  return <Text style={[{ color: colors[themeColor] }, typeStyles[type], style]} {...rest} />;
+  const { colors, tokens } = useTheme();
+
+  const typographyName: TypographyTokenName = isLegacy(type) ? legacyTypeMap[type] : type;
+  if (isLegacy(type)) {
+    warnLegacyType(type, typographyName);
+  }
+
+  const color = themeColor
+    ? colors[themeColor]
+    : tone === "accent"
+      ? tokens.color.accent.text
+      : tokens.color.text[tone];
+
+  return (
+    <Text
+      style={[
+        Typography[typographyName],
+        isLegacy(type) ? legacyDecoration[type] : undefined,
+        { color },
+        weight ? { fontWeight: fontWeightMap[weight] } : undefined,
+        align ? { textAlign: align } : undefined,
+        style,
+      ]}
+      {...rest}
+    />
+  );
 }

--- a/apps/sandbox/src/constants/theme.ts
+++ b/apps/sandbox/src/constants/theme.ts
@@ -1,70 +1,35 @@
-import { Platform } from "react-native";
+// 旧 API。新規コードは ../theme/tokens/<name> から直接 import すること。
+// 既存呼び出し箇所は第2段以降で順次置換する。
+import { semanticColors } from "../theme/tokens/colors";
+
+export type { ColorScheme } from "../theme/tokens/colors";
+export { Spacing, type SpacingName } from "../theme/tokens/spacing";
+export { Fonts } from "../theme/tokens/typography";
 
 export const Colors = {
   light: {
-    text: "#000000",
-    textSecondary: "#60646C",
-    background: "#ffffff",
-    backgroundElement: "#F0F0F3",
-    backgroundSelected: "#E0E1E6",
-    backgroundHeader: "rgb(255, 255, 255)",
-    border: "rgb(216, 216, 216)",
-    primary: "rgb(0, 122, 255)",
-    onPrimary: "#ffffff",
+    text: semanticColors.light.text.primary,
+    textSecondary: semanticColors.light.text.secondary,
+    background: semanticColors.light.background.canvas,
+    backgroundElement: semanticColors.light.background.surface,
+    backgroundSelected: semanticColors.light.background.pressed,
+    backgroundHeader: semanticColors.light.background.canvas,
+    border: semanticColors.light.border.subtle,
+    primary: semanticColors.light.accent.solid,
+    onPrimary: semanticColors.light.text.onAccent,
   },
   dark: {
-    text: "#ffffff",
-    textSecondary: "#B0B4BA",
-    background: "#000000",
-    backgroundElement: "#212225",
-    backgroundSelected: "#2E3135",
-    backgroundHeader: "rgb(18, 18, 18)",
-    border: "rgb(39, 39, 41)",
-    primary: "rgb(10, 132, 255)",
-    onPrimary: "#000000",
+    text: semanticColors.dark.text.primary,
+    textSecondary: semanticColors.dark.text.secondary,
+    background: semanticColors.dark.background.canvas,
+    backgroundElement: semanticColors.dark.background.surface,
+    backgroundSelected: semanticColors.dark.background.pressed,
+    backgroundHeader: semanticColors.dark.background.canvas,
+    border: semanticColors.dark.border.subtle,
+    primary: semanticColors.dark.accent.solid,
+    onPrimary: semanticColors.dark.text.onAccent,
   },
 } as const;
 
-export type ColorScheme = keyof typeof Colors;
 export type ColorTokenName = keyof (typeof Colors)["light"];
 export type ColorTokens = Readonly<Record<ColorTokenName, string>>;
-
-export const Spacing = {
-  half: 2,
-  one: 4,
-  two: 8,
-  three: 16,
-  four: 24,
-  five: 32,
-  six: 64,
-} as const;
-
-export type SpacingName = keyof typeof Spacing;
-
-interface FontFamily {
-  sans: string;
-  serif: string;
-  rounded: string;
-  mono: string;
-}
-
-export const Fonts: FontFamily = Platform.select({
-  ios: {
-    sans: "system-ui",
-    serif: "ui-serif",
-    rounded: "ui-rounded",
-    mono: "ui-monospace",
-  },
-  android: {
-    sans: "normal",
-    serif: "serif",
-    rounded: "normal",
-    mono: "monospace",
-  },
-  default: {
-    sans: "normal",
-    serif: "serif",
-    rounded: "normal",
-    mono: "monospace",
-  },
-});

--- a/apps/sandbox/src/theme/ThemeContext.tsx
+++ b/apps/sandbox/src/theme/ThemeContext.tsx
@@ -3,6 +3,11 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 import { Appearance, useColorScheme } from "react-native";
 import Storage from "expo-sqlite/kv-store";
 import { Colors, type ColorScheme, type ColorTokens } from "../constants/theme";
+import { semanticColors, type SemanticColorTokens } from "./tokens/colors";
+import { Radius } from "./tokens/radius";
+import { shadowsByScheme, type ShadowTokens } from "./tokens/shadows";
+import { Spacing } from "./tokens/spacing";
+import { Typography } from "./tokens/typography";
 
 export type ThemeMode = "system" | "light" | "dark";
 
@@ -10,11 +15,20 @@ const STORAGE_KEY = {
   THEME_MODE: "theme-mode",
 } as const;
 
+export interface ThemeTokens {
+  color: SemanticColorTokens;
+  spacing: typeof Spacing;
+  radius: typeof Radius;
+  shadow: ShadowTokens;
+  typography: typeof Typography;
+}
+
 export interface ThemeContextValue {
   mode: ThemeMode;
   setMode: (mode: ThemeMode) => void;
   colorScheme: ColorScheme;
   colors: ColorTokens;
+  tokens: ThemeTokens;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -39,6 +53,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const colors = Colors[colorScheme];
 
+  const tokens = useMemo<ThemeTokens>(
+    () => ({
+      color: semanticColors[colorScheme],
+      spacing: Spacing,
+      radius: Radius,
+      shadow: shadowsByScheme[colorScheme],
+      typography: Typography,
+    }),
+    [colorScheme],
+  );
+
   // iOS の overrideUserInterfaceStyle をアプリ設定に揃える。
   // これをやらないと NativeTabs などのネイティブ UI が OS 設定側を
   // 参照し続け、アプリ内でダーク強制してもタブ切替時にライト色が
@@ -58,8 +83,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       setMode: handleSetMode,
       colorScheme,
       colors,
+      tokens,
     }),
-    [mode, handleSetMode, colorScheme, colors],
+    [mode, handleSetMode, colorScheme, colors, tokens],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/apps/sandbox/src/theme/navigationScreenOptions.ts
+++ b/apps/sandbox/src/theme/navigationScreenOptions.ts
@@ -1,4 +1,4 @@
-import type { ColorScheme, ColorTokens } from "../constants/theme";
+import type { ColorScheme, SemanticColorTokens } from "./tokens/colors";
 
 interface StackScreenOptions {
   headerStyle: { backgroundColor: string };
@@ -7,12 +7,12 @@ interface StackScreenOptions {
 }
 
 export function buildStackScreenOptions(
-  colors: ColorTokens,
+  color: SemanticColorTokens,
   colorScheme: ColorScheme,
 ): StackScreenOptions {
   return {
-    headerStyle: { backgroundColor: colors.backgroundHeader },
-    headerTintColor: colors.text,
+    headerStyle: { backgroundColor: color.background.canvas },
+    headerTintColor: color.text.primary,
     headerShadowVisible: colorScheme === "light",
   };
 }

--- a/apps/sandbox/src/theme/tokens/colors.ts
+++ b/apps/sandbox/src/theme/tokens/colors.ts
@@ -1,0 +1,154 @@
+// WCAG コントラスト比 (light / dark で text vs background):
+// - text.primary (#1A1A1A on #FFFFFF / #FAFAFA on #0B0B0B) ≈ 17.8:1 / 18.5:1 (AAA)
+// - text.secondary on canvas ≈ 6.97:1 / 9.85:1 (AAA)
+// 参考: docs.expo.dev のアクセシビリティガイド / WCAG 2.2
+
+export type ColorScheme = "light" | "dark";
+
+type GrayScale = readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+];
+
+const lightNeutral: GrayScale = [
+  "#FFFFFF",
+  "#FCFCFC",
+  "#F8F8F8",
+  "#F1F1F1",
+  "#EBEBEB",
+  "#E4E4E4",
+  "#DCDCDC",
+  "#D2D2D2",
+  "#C0C0C0",
+  "#8F8F8F",
+  "#7C7C7C",
+  "#5F5F5F",
+  "#1A1A1A",
+];
+
+const darkNeutral: GrayScale = [
+  "#0B0B0B",
+  "#111111",
+  "#151515",
+  "#1E1E1E",
+  "#232323",
+  "#282828",
+  "#2E2E2E",
+  "#383838",
+  "#494949",
+  "#6F6F6F",
+  "#888888",
+  "#B0B0B0",
+  "#FAFAFA",
+];
+
+const lightAccent: GrayScale = [
+  "#FBFDFF",
+  "#F4FAFF",
+  "#E6F2FF",
+  "#D5E9FF",
+  "#C2DEFF",
+  "#ACD0FF",
+  "#8EBDFF",
+  "#5FA2FF",
+  "#3B8BFF",
+  "#007AFF",
+  "#006FE7",
+  "#005EC4",
+  "#002F66",
+];
+
+const darkAccent: GrayScale = [
+  "#0A1421",
+  "#0E1E33",
+  "#102844",
+  "#133358",
+  "#16406C",
+  "#1A4F87",
+  "#1F61A9",
+  "#2778CC",
+  "#0568D9",
+  "#0A84FF",
+  "#2F90FF",
+  "#7CB6FF",
+  "#E2EEFF",
+];
+
+export const palette = {
+  light: { neutral: lightNeutral, accent: lightAccent },
+  dark: { neutral: darkNeutral, accent: darkAccent },
+} as const;
+
+interface SemanticColorTokens {
+  background: {
+    canvas: string;
+    surface: string;
+    surfaceElevated: string;
+    subtle: string;
+    pressed: string;
+  };
+  border: {
+    subtle: string;
+    default: string;
+    strong: string;
+  };
+  text: {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    disabled: string;
+    onAccent: string;
+    link: string;
+  };
+  accent: {
+    solid: string;
+    solidHover: string;
+    text: string;
+  };
+}
+
+export type { SemanticColorTokens };
+
+const buildSemantic = (n: GrayScale, a: GrayScale): SemanticColorTokens => ({
+  background: {
+    canvas: n[0],
+    surface: n[1],
+    surfaceElevated: n[2],
+    subtle: n[3],
+    pressed: n[4],
+  },
+  border: {
+    subtle: n[5],
+    default: n[7],
+    strong: n[8],
+  },
+  text: {
+    primary: n[12],
+    secondary: n[11],
+    tertiary: n[10],
+    disabled: n[8],
+    onAccent: n[0],
+    link: a[11],
+  },
+  accent: {
+    solid: a[9],
+    solidHover: a[10],
+    text: a[11],
+  },
+});
+
+export const semanticColors = {
+  light: buildSemantic(lightNeutral, lightAccent),
+  dark: buildSemantic(darkNeutral, darkAccent),
+} as const;

--- a/apps/sandbox/src/theme/tokens/radius.ts
+++ b/apps/sandbox/src/theme/tokens/radius.ts
@@ -1,0 +1,11 @@
+export const Radius = {
+  none: 0,
+  xs: 4,
+  sm: 6,
+  md: 10,
+  lg: 14,
+  xl: 20,
+  full: 9999,
+} as const;
+
+export type RadiusTokenName = keyof typeof Radius;

--- a/apps/sandbox/src/theme/tokens/shadows.ts
+++ b/apps/sandbox/src/theme/tokens/shadows.ts
@@ -1,0 +1,58 @@
+import { Platform, type ViewStyle } from "react-native";
+import type { ColorScheme } from "./colors";
+
+export type ShadowTokenName = "none" | "sm" | "md" | "lg";
+
+type ShadowValue = Pick<
+  ViewStyle,
+  "shadowColor" | "shadowOffset" | "shadowOpacity" | "shadowRadius" | "elevation"
+>;
+
+export type ShadowTokens = Readonly<Record<ShadowTokenName, ShadowValue>>;
+
+const baseColor = "#000000";
+
+const iosShadows = (opacityScale: number): ShadowTokens => ({
+  none: {},
+  sm: {
+    shadowColor: baseColor,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06 * opacityScale,
+    shadowRadius: 4,
+  },
+  md: {
+    shadowColor: baseColor,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08 * opacityScale,
+    shadowRadius: 10,
+  },
+  lg: {
+    shadowColor: baseColor,
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.12 * opacityScale,
+    shadowRadius: 20,
+  },
+});
+
+const androidShadows: ShadowTokens = {
+  none: { elevation: 0 },
+  sm: { elevation: 1 },
+  md: { elevation: 4 },
+  lg: { elevation: 10 },
+};
+
+// dark テーマでは shadow を控えめにし border 強化で階層を表現する。
+// 完全に 0 にはせず、Modal / sheet の浮き感は維持する。
+const makeShadows = (colorScheme: ColorScheme): ShadowTokens => {
+  const opacityScale = colorScheme === "dark" ? 2.5 : 1;
+  return Platform.select({
+    ios: iosShadows(opacityScale),
+    android: androidShadows,
+    default: { none: {}, sm: {}, md: {}, lg: {} } as ShadowTokens,
+  });
+};
+
+export const shadowsByScheme = {
+  light: makeShadows("light"),
+  dark: makeShadows("dark"),
+} as const;

--- a/apps/sandbox/src/theme/tokens/spacing.ts
+++ b/apps/sandbox/src/theme/tokens/spacing.ts
@@ -1,0 +1,21 @@
+export const Spacing = {
+  none: 0,
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  "2xl": 32,
+  "3xl": 48,
+  "4xl": 64,
+  // 旧名 alias (第2段で削除予定。新コードは xs..4xl を使うこと)
+  half: 2,
+  one: 4,
+  two: 8,
+  three: 16,
+  four: 24,
+  five: 32,
+  six: 64,
+} as const;
+
+export type SpacingName = keyof typeof Spacing;

--- a/apps/sandbox/src/theme/tokens/typography.ts
+++ b/apps/sandbox/src/theme/tokens/typography.ts
@@ -1,0 +1,50 @@
+import { Platform, type TextStyle } from "react-native";
+
+interface FontFamily {
+  sans: string;
+  serif: string;
+  rounded: string;
+  mono: string;
+}
+
+export const Fonts: FontFamily = Platform.select({
+  ios: {
+    sans: "system-ui",
+    serif: "ui-serif",
+    rounded: "ui-rounded",
+    mono: "ui-monospace",
+  },
+  android: {
+    sans: "normal",
+    serif: "serif",
+    rounded: "normal",
+    mono: "monospace",
+  },
+  default: {
+    sans: "normal",
+    serif: "serif",
+    rounded: "normal",
+    mono: "monospace",
+  },
+});
+
+export type TypographyTokenName =
+  | "displayLg"
+  | "title"
+  | "headline"
+  | "body"
+  | "bodyEmphasis"
+  | "label"
+  | "caption"
+  | "code";
+
+export const Typography: Record<TypographyTokenName, TextStyle> = {
+  displayLg: { fontSize: 34, lineHeight: 40, fontWeight: "700" },
+  title: { fontSize: 28, lineHeight: 34, fontWeight: "700" },
+  headline: { fontSize: 20, lineHeight: 26, fontWeight: "600" },
+  body: { fontSize: 16, lineHeight: 24, fontWeight: "400" },
+  bodyEmphasis: { fontSize: 16, lineHeight: 24, fontWeight: "600" },
+  label: { fontSize: 14, lineHeight: 20, fontWeight: "500" },
+  caption: { fontSize: 12, lineHeight: 16, fontWeight: "400" },
+  code: { fontSize: 14, lineHeight: 20, fontWeight: "400", fontFamily: Fonts.mono },
+};

--- a/apps/sandbox/src/theme/useTheme.ts
+++ b/apps/sandbox/src/theme/useTheme.ts
@@ -1,7 +1,11 @@
 import type { ColorScheme, ColorTokens } from "../constants/theme";
-import { useThemeContextInternal } from "./ThemeContext";
+import { useThemeContextInternal, type ThemeTokens } from "./ThemeContext";
 
-export function useTheme(): { colorScheme: ColorScheme; colors: ColorTokens } {
-  const { colorScheme, colors } = useThemeContextInternal();
-  return { colorScheme, colors };
+export function useTheme(): {
+  colorScheme: ColorScheme;
+  colors: ColorTokens;
+  tokens: ThemeTokens;
+} {
+  const { colorScheme, colors, tokens } = useThemeContextInternal();
+  return { colorScheme, colors, tokens };
 }

--- a/tasks/design-refresh.md
+++ b/tasks/design-refresh.md
@@ -1,0 +1,67 @@
+# デザイン刷新ロードマップ
+
+## 背景
+
+`apps/sandbox` は Expo Router の学習用サンドボックス。サンプルとして置いていた `LinkList` / `ThemedText` が「汎用すぎ・地味・機能薄」で見本としての訴求力が弱く、また自前テーマシステム (`constants/theme.ts` + `ThemeContext`) のトークンが薄いため見た目を整える土台が足りていなかった。
+
+UI ライブラリ (NativeWind / Tamagui 等) は **採用しない**。自前テーマシステムを洗練し、Expo / React Native の API だけで仕上げる方針。
+
+関連: [`tasks/accessibility-audit.md`](./accessibility-audit.md) — テーマのコントラスト・タッチターゲット等は本ロードマップと整合させる。
+
+## 採用方針
+
+- semantic color: `background.* / border.* / text.* / accent.*` の 2 層 (palette → semantic) で構造化。Radix Gray 風の 13 階調 + Apple システムブルー風アクセント。
+- spacing は 4 倍数ベース。`xs / sm / md / lg / xl / 2xl / 3xl / 4xl` に統一。
+- radius / shadow / typography トークンを新設。typography は Material 3 と Apple HIG の中間の 8 段階。
+- `useTheme()` の戻り値: `{ colorScheme, colors (旧フラット互換), tokens: { color, spacing, radius, shadow, typography } }`。
+
+## 第1段 (PR 完了予定)
+
+スコープ: **テーマトークン整備 + ThemedText 刷新**。LinkList の見た目刷新は **しない** (色変更とは別レビューにしたいため第2段へ)。
+
+完了条件:
+- [x] `apps/sandbox/src/theme/tokens/{colors,spacing,radius,shadows,typography}.ts` を新規追加 (barrel `index.ts` は置かない)
+- [x] `constants/theme.ts` を新トークン参照の旧 API シムに置換 (`Colors` は semantic から構築、`Spacing`/`Fonts` は単一モジュールから delegate)
+- [x] `ThemeContext` / `useTheme` の戻り値に `tokens` を追加
+- [x] `navigationScreenOptions.ts` を semantic 参照に切り替え
+- [x] `ThemedText` を新 type (`displayLg/title/headline/body/bodyEmphasis/label/caption/code`) + `weight` / `tone` / `align` prop に刷新。旧 type は内部マップで後方互換維持し dev 警告。
+- [x] `LinkList` は新トークン参照に差し替えのみ (見た目は据え置き)。chevron は `text.tertiary`、押下背景は `background.pressed`。
+- [ ] `pnpm -r run lint` 通過
+- [ ] iOS / Android / Web で light/dark 切替確認
+
+## 第2段
+
+スコープ: **LinkList 刷新 + 関連コンポーネントの semantic 化**。
+
+- iOS Settings 風 grouped list:
+  - 外側: `background.canvas` + `Spacing.xl` の padding
+  - 島: `background.surface` + `Radius.lg` + `Shadows.sm` (dark は border 強化)
+  - 行間 separator: 先頭以外に `borderTopWidth: StyleSheet.hairlineWidth` + `border.subtle` (左に paddingLeft 分のインセット)
+- `LinkItem` 拡張 props: `description?` (2 行目) / `leadingIcon?` / `trailingBadge?` / `disabled?`
+- セクション対応: `LinkSection` wrapper を新設 (title / footer / data)。`SectionList` ではなく `View` の縦並びで十分。
+- `ThemedView` に semantic tone prop (canvas / surface / surfaceElevated / subtle) を追加
+- `ThemedLink` を切り出し: `<Link asChild>` + `<Pressable>` + `<ThemedText tone="accent">` を内包。`ThemedText` の `link` / `linkPrimary` type と `themeColor` prop はここで削除。
+- 旧 Spacing alias (`one/two/three/four/five/six/half`) の grep 一括置換 + alias 削除
+- ホーム / 設定画面のリンクを section 構造に再編 (空に近い画面は項目を補充する案も)
+
+## 第3段以降
+
+Expo らしい新規サンプルコンポーネントの追加。
+
+候補 (優先度は未確定):
+- `Button` (variants: solid / soft / ghost / outline、leading icon 等)
+- `Card` (surface elevation + padding 規約)
+- `Section` / `ListRow` (LinkList の派生で非リンク版)
+- `BlurView` を活用したヘッダ / overlay サンプル (`expo-blur`)
+- `Haptics` 連動の押下フィードバック (`expo-haptics`)
+- SF Symbols / Material Symbols 連動アイコン (`expo-symbols`)
+- DOM コンポーネント (`use dom`) のサンプル
+
+## 後方互換 alias の削除計画
+
+| 対象 | 削除トリガ |
+| --- | --- |
+| `constants/theme.ts` の re-export shim | 第2段で全箇所を `theme/tokens` 直 import に置換した後 |
+| `Spacing.half/one/two/three/four/five/six` | 第2段で `PresentationSample*` 系を `xs..4xl` に置換した後 |
+| `ThemedText` の旧 type (`default/subtitle/small/smallBold/link/linkPrimary`) | 第2段で `LinkList` 刷新と同時に呼び出し側 9 箇所を移行した後 |
+| `ThemedText` の `themeColor` prop | 同上 (`tone` に統一) |


### PR DESCRIPTION
## 概要

デザイン刷新の第 1 段。自前テーマシステムに semantic トークン (palette → semantic の 2 層構造) と Radius / Shadows / Typography を導入し、`ThemedText` の type 体系を整理した。既存呼び出し箇所は後方互換 alias で維持し、画面の見た目はほぼ据え置き。

第 2 段以降のロードマップは [`tasks/design-refresh.md`](../tree/refactor/theme-tokens-foundation/tasks/design-refresh.md) に記録。

## 背景・動機

- アプリ (`apps/sandbox`) は Expo Router の学習用サンドボックス。サンプルとして置いている `LinkList` / `ThemedText` が「汎用すぎ・地味・機能薄」で見本としての訴求力が弱かった。
- 自前テーマ (`constants/theme.ts` + `ThemeContext`) のトークンも薄く、見た目を整える土台が不足。
- 「いい感じのデザインを当てたい」という要望を、UI ライブラリ (NativeWind / Tamagui 等) を入れずに既存テーマの洗練で実現する方針。
- 一度に LinkList の見た目刷新まで含めると差分が「色の変更」と「構造の変更」で混ざってレビューしづらいので、段階分けして本 PR は土台整備に絞る。

## アプローチ

- **トークン分割**: `apps/sandbox/src/theme/tokens/` に `colors / spacing / radius / shadows / typography` を分割配置。barrel `index.ts` は置かず、各呼び出し側で個別 import。
- **カラーは 2 層構造**: palette (neutral 13 階調 + accent 13 階調 / light dark) → semantic (`background.* / border.* / text.* / accent.*`)。WCAG AA 以上を満たす組合せを選定。
- **Spacing は 4 の倍数ベース**: `xs / sm / md / lg / xl / 2xl / 3xl / 4xl`。旧名 (`half/one/two/three/four/five/six`) は alias で残し、既存利用箇所は触らない。
- **Radius / Shadows / Typography 新設**: Shadows は light/dark で強度を変える colorScheme-aware。Typography は Material 3 と Apple HIG の中間を取った 8 段階。
- **`useTheme` の戻り値拡張**: 既存の `colors` (旧フラット形) を維持しつつ `tokens: { color, spacing, radius, shadow, typography }` を追加。新コードは `tokens.*` 経由で書ける。
- **ThemedText 刷新**: 新 type (`displayLg/title/headline/body/bodyEmphasis/label/caption/code`) + `weight` / `tone` / `align` prop に再設計。旧 type と `themeColor` prop は内部マップで後方互換維持し dev で deprecation 警告。第 2 段で削除予定。
- **LinkList は最小差し替え**: chevron 色を `text.tertiary` に。当初は押下背景フィードバック (`background.pressed`) も入れたが、`<Link asChild>` 配下の Slot が内部で `StyleSheet.flatten` を呼ぶため function 形式の `style` が破棄され、行が縦並びに崩れる事象に当たったので削除 (21fa579)。押下フィードバックを含む見た目刷新 (iOS 風 grouped list 化 / props 拡張) は第 2 段で `Link asChild` を使わない構造に再設計する。
- **却下した代替案**:
  - NativeWind / Tamagui 等の UI ライブラリ導入 — 自前テーマシステムを継続する方針で却下。
  - LinkList の grouped list 化を本 PR に同梱 — 色の差分と構造の差分を分けるため第 2 段に分離。
  - `tokens/index.ts` での一括 re-export — barrel を積極採用しない運用方針に合わせて削除。

## レビューポイント

- `theme/tokens/colors.ts` のパレット選定 (neutral / Apple システムブルー風アクセント)。
- `ThemedText` の旧 type マップ (`legacyTypeMap`) — 旧 `title` (32px) → 新 `title` (28px) でサイズが少し縮む点。
- 第 2 段に持ち越した制約: `<Link asChild>` 配下の Slot は `StyleSheet.flatten` が function style に対応していない (`node_modules/expo-router/build/ui/Slot.js`)。pressed フィードバックや state 連動スタイルを入れるなら、`Link asChild` を使わず `onPress` で `router.navigate` する構造に切り替える必要がある。
- 動作確認: light/dark 切替、ホーム / 設定 / theme 切替画面、navigation-patterns 一覧、7 種類のモーダル (card / modal / transparent-modal / contained-modal / contained-transparent-modal / full-screen-modal / form-sheet) の表示崩れ確認。
- `tasks/design-refresh.md` の第 2 段以降ロードマップの妥当性。

## Test plan

- [x] `pnpm -r run lint`
- [ ] `pnpm --dir apps/sandbox run ios` で各画面の light/dark 表示確認
- [ ] `pnpm --dir apps/sandbox run android` で各画面の light/dark 表示確認
- [ ] `pnpm --dir apps/sandbox run web` で各画面の light/dark 表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)