### PR TITLE
fix(form-sheet): タブ内 formSheet で中身が空白になる問題を修正

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { View } from "react-native";
 import { Stack } from "expo-router";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { PresentationSampleScreen } from "../../../../../components/presentation-sample/PresentationSampleScreen";
@@ -9,51 +10,59 @@ export default function FormSheetSample(): ReactElement {
   return (
     <>
       <Stack.Screen.Title>{t`formSheet`}</Stack.Screen.Title>
-      <PresentationSampleScreen
-        presentationValue="formSheet"
-        heading={<Trans>タブ内 Stack 上のシート表示</Trans>}
-        iosBehavior={
-          <Trans>
-            UIModalPresentationFormSheet で表示される。タブ内 Stack 配下に置いても iOS の formSheet
-            は UIKit 上の最前面に出るため、タブバーを覆って表示される (on-root
-            版とほぼ同じ見た目)。detent (snap point) や sheetGrabberVisible
-            の挙動は配置に依存しない。
-          </Trans>
-        }
-        androidBehavior={
-          <Trans>
-            BottomSheetBehavior で表示される。タブ内 Stack 配下に置くと、**タブバーが残った まま**
-            tab content の領域内にボトムシートが出る形になる (Android は presentation context
-            の概念がないため、Stack の階層が反映される)。detent は最大 3 つまで。
-          </Trans>
-        }
-        dismissNote={
-          <Trans>
-            下方向の swipe、grabber のドラッグ、または「閉じる」ボタンで閉じる。Android
-            では戻る操作でも閉じる。**Android でタブバーが残ったままシートが出る**のが on-root
-            版との最大の差分。実プロダクトではルート配置を推奨。
-          </Trans>
-        }
-        additionalNotes={
-          <Trans>
-            Android の formSheet は CoordinatorLayout 上の BottomSheetBehavior
-            として実装される。シート内に ScrollView を置く場合は `nestedScrollEnabled` を true
-            にしてシートの drag と nested scroll を連携させる必要がある (詳細:
-            react-native-screens#2687)。
-            {"\n\n"}
-            さらに RN 0.83 の Android ScrollView には「コンテンツの実高さが ScrollView
-            より短い場合、OnInterceptTouchEvent が常に false を返し nested scroll event を一切
-            dispatch しない」既知の挙動があり、シート内コンテンツが領域に収まる
-            場合は下スワイプによるシートの dismiss が動かなくなる。RN 側のフィックス
-            (facebook/react-native#55239) は `useNestedScrollViewAndroid` feature flag 経由で RN
-            0.84 以降に入る見込み。
-            {"\n\n"}
-            そのため SDK 55 ではシート内のコンテンツがシート高さを上回るボリュームに
-            なるよう設計するか、grabber や明示的な閉じるボタンを必ず併設するのが安全。
-            このサンプル画面はその制約を満たすためにこのメモ自体でコンテンツを伸ばして いる。
-          </Trans>
-        }
-      />
+      {/*
+        タブ内 (NativeTabs) にネストした Stack から formSheet を提示すると、iOS で内側の
+        ScrollView の中身が高さ 0 に潰れて空白になる rn-screens のレイアウト問題がある (issue #140)。
+        flatten されない実体のあるネイティブビューを 1 枚挟むと回避できるため、collapsable={false}
+        の View でラップする (view flattening を抑止)。inset は不要なので SafeAreaView は使わない。
+      */}
+      <View style={{ flex: 1 }} collapsable={false}>
+        <PresentationSampleScreen
+          presentationValue="formSheet"
+          heading={<Trans>タブ内 Stack 上のシート表示</Trans>}
+          iosBehavior={
+            <Trans>
+              UIModalPresentationFormSheet で表示される。タブ内 Stack 配下に置いても iOS の
+              formSheet は UIKit 上の最前面に出るため、タブバーを覆って表示される (on-root
+              版とほぼ同じ見た目)。detent (snap point) や sheetGrabberVisible
+              の挙動は配置に依存しない。
+            </Trans>
+          }
+          androidBehavior={
+            <Trans>
+              BottomSheetBehavior で表示される。タブ内 Stack 配下に置くと、**タブバーが残った まま**
+              tab content の領域内にボトムシートが出る形になる (Android は presentation context
+              の概念がないため、Stack の階層が反映される)。detent は最大 3 つまで。
+            </Trans>
+          }
+          dismissNote={
+            <Trans>
+              下方向の swipe、grabber のドラッグ、または「閉じる」ボタンで閉じる。Android
+              では戻る操作でも閉じる。**Android でタブバーが残ったままシートが出る**のが on-root
+              版との最大の差分。実プロダクトではルート配置を推奨。
+            </Trans>
+          }
+          additionalNotes={
+            <Trans>
+              Android の formSheet は CoordinatorLayout 上の BottomSheetBehavior
+              として実装される。シート内に ScrollView を置く場合は `nestedScrollEnabled` を true
+              にしてシートの drag と nested scroll を連携させる必要がある (詳細:
+              react-native-screens#2687)。
+              {"\n\n"}
+              さらに RN 0.83 の Android ScrollView には「コンテンツの実高さが ScrollView
+              より短い場合、OnInterceptTouchEvent が常に false を返し nested scroll event を一切
+              dispatch しない」既知の挙動があり、シート内コンテンツが領域に収まる
+              場合は下スワイプによるシートの dismiss が動かなくなる。RN 側のフィックス
+              (facebook/react-native#55239) は `useNestedScrollViewAndroid` feature flag 経由で RN
+              0.84 以降に入る見込み。
+              {"\n\n"}
+              そのため SDK 55 ではシート内のコンテンツがシート高さを上回るボリュームに
+              なるよう設計するか、grabber や明示的な閉じるボタンを必ず併設するのが安全。
+              このサンプル画面はその制約を満たすためにこのメモ自体でコンテンツを伸ばして いる。
+            </Trans>
+          }
+        />
+      </View>
     </>
   );
 }

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -30,7 +30,7 @@ msgid ""
 "そのため SDK 55 ではシート内のコンテンツがシート高さを上回るボリュームに なるよう設計するか、grabber や明示的な閉じるボタンを必ず併設するのが安全。 このサンプル画面はその制約を満たすためにこのメモ自体でコンテンツを伸ばして いる。"
 msgstr ""
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:38
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:46
 msgid ""
 "Android の formSheet は CoordinatorLayout 上の BottomSheetBehavior として実装される。シート内に ScrollView を置く場合は `nestedScrollEnabled` を true にしてシートの drag と nested scroll を連携させる必要がある (詳細: react-native-screens#2687)。\n"
 "\n"
@@ -47,7 +47,7 @@ msgstr "Android behavior"
 msgid "BottomSheetBehavior で表示される。detent は最大 3 つまで。sheetGrabberVisible は無視され、代わりに sheetElevation 等の Android 専用オプションがある。 ルート Stack 配下なのでタブバーを覆ってシートが出る。"
 msgstr "Presented with BottomSheetBehavior. Limited to up to 3 detents. `sheetGrabberVisible` is ignored; Android-only options such as `sheetElevation` apply instead. Since it sits under the root Stack, the sheet covers the tab bar when it appears."
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:24
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:32
 msgid "BottomSheetBehavior で表示される。タブ内 Stack 配下に置くと、**タブバーが残った まま** tab content の領域内にボトムシートが出る形になる (Android は presentation context の概念がないため、Stack の階層が反映される)。detent は最大 3 つまで。"
 msgstr "Presented with BottomSheetBehavior. When placed under the in-tab Stack, the bottom sheet appears within the tab content area **with the tab bar still visible** (Android has no concept of presentation context, so the Stack hierarchy is reflected directly). Limited to up to 3 detents."
 
@@ -83,7 +83,7 @@ msgstr "containedTransparentModal"
 msgid "expo-haptics 連動の押下フィードバック。Web は no-op"
 msgstr "Press feedback via expo-haptics. No-op on Web"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:12
 #: src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx:28
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:31
 #: src/app/navigation-patterns/form-sheet/on-root.tsx:12
@@ -243,7 +243,7 @@ msgstr "Presented with UIModalPresentationCurrentContext. The intended behavior 
 msgid "UIModalPresentationFormSheet で表示される。detent (snap point) を任意の数だけ指定可。sheetGrabberVisible で上端のつまみを表示できる。 ルート Stack 配下なのでタブバーを覆ってシートが下から出る形になる (formSheet は通常 modal 同様タブバー上に乗るのが期待される挙動)。"
 msgstr "Presented with UIModalPresentationFormSheet. Any number of detents (snap points) can be configured. `sheetGrabberVisible` shows the grabber at the top. Since it sits under the root Stack, the sheet rises from the bottom covering the tab bar (formSheet is generally expected to sit above the tab bar, the same as a modal)."
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:16
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:24
 msgid "UIModalPresentationFormSheet で表示される。タブ内 Stack 配下に置いても iOS の formSheet は UIKit 上の最前面に出るため、タブバーを覆って表示される (on-root 版とほぼ同じ見た目)。detent (snap point) や sheetGrabberVisible の挙動は配置に依存しない。"
 msgstr "Presented with UIModalPresentationFormSheet. Even when placed under the in-tab Stack, iOS's formSheet comes up at the front of UIKit's hierarchy, so it covers the tab bar (visually nearly identical to the on-root variant). Detents (snap points) and `sheetGrabberVisible` behavior do not depend on placement."
 
@@ -312,7 +312,7 @@ msgstr "containedModal on the in-tab Stack (intended behavior)"
 msgid "タブ内 Stack 上の containedTransparentModal (本来挙動)"
 msgstr "containedTransparentModal on the in-tab Stack (intended behavior)"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:14
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:22
 msgid "タブ内 Stack 上のシート表示"
 msgstr "Sheet presentation on the in-tab Stack"
 
@@ -439,7 +439,7 @@ msgstr "A page sheet-style modal that slides up from the bottom. Even when place
 msgid "下から上にスライドして表示される標準の page sheet 風 modal。ルート Stack 配下なので、タブバーごと画面全体を覆う形で重なる (in-tab 版でも iOS では modal がタブバーを覆うため見た目はほぼ同じ)。上端からの swipe down で閉じられる。"
 msgstr "A standard page sheet-style modal that slides up from the bottom. Since it sits under the root Stack, it overlays the entire screen including the tab bar (the in-tab variant also covers the tab bar on iOS, so the appearance is nearly the same). Dismissed via swipe down from the top edge."
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:31
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:39
 msgid "下方向の swipe、grabber のドラッグ、または「閉じる」ボタンで閉じる。Android では戻る操作でも閉じる。**Android でタブバーが残ったままシートが出る**のが on-root 版との最大の差分。実プロダクトではルート配置を推奨。"
 msgstr "Dismiss by swiping down, dragging the grabber, or pressing the Close button. Android also dismisses on back navigation. **The sheet appearing with the tab bar still visible on Android** is the key differentiator versus the on-root variant. Root placement is recommended in real products."
 

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -35,7 +35,7 @@ msgstr ""
 "\n"
 "そのため SDK 55 ではシート内のコンテンツがシート高さを上回るボリュームに なるよう設計するか、grabber や明示的な閉じるボタンを必ず併設するのが安全。 このサンプル画面はその制約を満たすためにこのメモ自体でコンテンツを伸ばして いる。"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:38
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:46
 msgid ""
 "Android の formSheet は CoordinatorLayout 上の BottomSheetBehavior として実装される。シート内に ScrollView を置く場合は `nestedScrollEnabled` を true にしてシートの drag と nested scroll を連携させる必要がある (詳細: react-native-screens#2687)。\n"
 "\n"
@@ -57,7 +57,7 @@ msgstr "Android の挙動"
 msgid "BottomSheetBehavior で表示される。detent は最大 3 つまで。sheetGrabberVisible は無視され、代わりに sheetElevation 等の Android 専用オプションがある。 ルート Stack 配下なのでタブバーを覆ってシートが出る。"
 msgstr "BottomSheetBehavior で表示される。detent は最大 3 つまで。sheetGrabberVisible は無視され、代わりに sheetElevation 等の Android 専用オプションがある。 ルート Stack 配下なのでタブバーを覆ってシートが出る。"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:24
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:32
 msgid "BottomSheetBehavior で表示される。タブ内 Stack 配下に置くと、**タブバーが残った まま** tab content の領域内にボトムシートが出る形になる (Android は presentation context の概念がないため、Stack の階層が反映される)。detent は最大 3 つまで。"
 msgstr "BottomSheetBehavior で表示される。タブ内 Stack 配下に置くと、**タブバーが残った まま** tab content の領域内にボトムシートが出る形になる (Android は presentation context の概念がないため、Stack の階層が反映される)。detent は最大 3 つまで。"
 
@@ -93,7 +93,7 @@ msgstr "containedTransparentModal"
 msgid "expo-haptics 連動の押下フィードバック。Web は no-op"
 msgstr "expo-haptics 連動の押下フィードバック。Web は no-op"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:11
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:12
 #: src/app/(tabs)/(home)/navigation-patterns/form-sheet/index.tsx:28
 #: src/app/(tabs)/(home)/navigation-patterns/index.tsx:31
 #: src/app/navigation-patterns/form-sheet/on-root.tsx:12
@@ -253,7 +253,7 @@ msgstr "UIModalPresentationCurrentContext で表示される。`definesPresentat
 msgid "UIModalPresentationFormSheet で表示される。detent (snap point) を任意の数だけ指定可。sheetGrabberVisible で上端のつまみを表示できる。 ルート Stack 配下なのでタブバーを覆ってシートが下から出る形になる (formSheet は通常 modal 同様タブバー上に乗るのが期待される挙動)。"
 msgstr "UIModalPresentationFormSheet で表示される。detent (snap point) を任意の数だけ指定可。sheetGrabberVisible で上端のつまみを表示できる。 ルート Stack 配下なのでタブバーを覆ってシートが下から出る形になる (formSheet は通常 modal 同様タブバー上に乗るのが期待される挙動)。"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:16
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:24
 msgid "UIModalPresentationFormSheet で表示される。タブ内 Stack 配下に置いても iOS の formSheet は UIKit 上の最前面に出るため、タブバーを覆って表示される (on-root 版とほぼ同じ見た目)。detent (snap point) や sheetGrabberVisible の挙動は配置に依存しない。"
 msgstr "UIModalPresentationFormSheet で表示される。タブ内 Stack 配下に置いても iOS の formSheet は UIKit 上の最前面に出るため、タブバーを覆って表示される (on-root 版とほぼ同じ見た目)。detent (snap point) や sheetGrabberVisible の挙動は配置に依存しない。"
 
@@ -322,7 +322,7 @@ msgstr "タブ内 Stack 上の containedModal (本来挙動)"
 msgid "タブ内 Stack 上の containedTransparentModal (本来挙動)"
 msgstr "タブ内 Stack 上の containedTransparentModal (本来挙動)"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:14
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:22
 msgid "タブ内 Stack 上のシート表示"
 msgstr "タブ内 Stack 上のシート表示"
 
@@ -449,7 +449,7 @@ msgstr "下から上にスライドして表示される page sheet 風 modal。
 msgid "下から上にスライドして表示される標準の page sheet 風 modal。ルート Stack 配下なので、タブバーごと画面全体を覆う形で重なる (in-tab 版でも iOS では modal がタブバーを覆うため見た目はほぼ同じ)。上端からの swipe down で閉じられる。"
 msgstr "下から上にスライドして表示される標準の page sheet 風 modal。ルート Stack 配下なので、タブバーごと画面全体を覆う形で重なる (in-tab 版でも iOS では modal がタブバーを覆うため見た目はほぼ同じ)。上端からの swipe down で閉じられる。"
 
-#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:31
+#: src/app/(tabs)/(home)/navigation-patterns/form-sheet/in-tab.tsx:39
 msgid "下方向の swipe、grabber のドラッグ、または「閉じる」ボタンで閉じる。Android では戻る操作でも閉じる。**Android でタブバーが残ったままシートが出る**のが on-root 版との最大の差分。実プロダクトではルート配置を推奨。"
 msgstr "下方向の swipe、grabber のドラッグ、または「閉じる」ボタンで閉じる。Android では戻る操作でも閉じる。**Android でタブバーが残ったままシートが出る**のが on-root 版との最大の差分。実プロダクトではルート配置を推奨。"
 


### PR DESCRIPTION
Closes #140

## 概要

タブ内 (NativeTabs にネストした Stack) から `presentation: "formSheet"` の画面を提示すると、iOS でシート内の `PresentationSampleScreen` が空白になる問題を修正します。

## 背景・動機

`navigation-patterns/form-sheet/in-tab` を formSheet で開くと、iOS ではシートは出るものの中身 (見出し / セクションカード / 閉じるボタン) が描画されず、Stack タイトル「formSheet」だけが表示されていました (iPhone 17 シミュレータで確認)。

切り分けの結果、リファクタ `b0b969f` (PresentationSampleScreen の責務分割) で in-tab 画面から `SafeAreaView` ラッパーが外れたことが原因と判明しました。rn-screens の formSheet content host は、タブ内ネスト提示時に「直下の子が `flex:1` + `ScrollView` 構造」だと ScrollView の中身を高さ 0 に測定する癖があり、コンテナ View 自体には高さがあるのに ScrollView の中身だけが潰れていました (コンテナを一時的に赤背景にしてシート全体が埋まることを確認済み)。

> なお issue 本文では on-root も対象と記載されていましたが、on-root は `SafeAreaView` を保持しており元から正常です (記載誤り)。影響は **formSheet の in-tab のみ**です。

## アプローチ

host とコンテンツの間に **flatten されない実体のあるネイティブビューを 1 枚挟む**ことで回避できます。`collapsable={false}` の `View` でラップしました。

実機で検証した代替案:

| 方法 | 結果 | 備考 |
|---|---|---|
| 素の `<View flex:1>` | ❌ | view flattening で実体が消え、層が増えない |
| `<View flex:1 collapsable={false}>` | ✅ | flattening を抑止しネイティブビューを強制（採用） |
| `<SafeAreaView edges={[]}>` | ✅ | 効くが inset 目的でない / Android で下部に余白が出る |
| ScrollView に `flex:1` | ❌ | 効かず |
| `Stack.Screen` の `contentStyle: { height: "100%" }` | ❌ | 効かず |
| `contentInsetAdjustmentBehavior` 変更 | ❌ | inset は無関係 |

`collapsable={false}` の View は (1) 追加 import 不要 (2) safe-area とは無関係という意図が正直 (3) Android で inset を一切付けない、ため採用しました。

## 確認済み / レビューポイント

- **iOS** (iPhone 17 シミュレータ): in-tab で見出し・全セクションの描画、クリッピングなしを確認
- **Android** (エミュレータ): in-tab の描画、および「閉じる」ボタン〜タブバー間の余分な余白が出ないことを確認
- 他の in-tab presentation (modal / card / fullScreenModal 等) は元々 `SafeAreaView` 無しで正常なため変更なし (回帰なし)
- `on-root` は無変更
