### PR TITLE
chore(pnpm): pnpm を 11.5.0 にアップグレード

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.5.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,9 @@
 packages:
   - apps/*
 
-nodeLinker: hoisted
+# ビルドスクリプトの実行可否（prebuilt バイナリを利用するため実行不要。従来の ignoredBuilds 挙動を維持）
+allowBuilds:
+  esbuild: false
+  unrs-resolver: false
 
-# Supply chain security
-# 公開から1日(1440分)経過していないバージョンのインストールは拒否
-minimumReleaseAge: 1440
-# 直接依存（package.jsonに記載されている依存）以外はGitリポジトリ、tarball URLを参照することをブロック
-blockExoticSubdeps: true
+nodeLinker: hoisted


### PR DESCRIPTION
## 概要

パッケージマネージャを pnpm 10.33.0 から **11.5.0** にメジャーアップグレードする。

## 背景・動機

pnpm 11.5.0 へのアップグレード依頼。pnpm 11 はサプライチェーン保護のデフォルト化やビルドスクリプト許可方式の刷新（`allowBuilds`）など複数の破壊的変更を含むため、影響を確認した上で必要な追従を行った。

## アプローチ

- **`package.json`**: `packageManager` を `pnpm@11.5.0` に更新（CI の `pnpm/action-setup@v6` はこのフィールドから自動解決するため CI も追従する）。
- **`pnpm-workspace.yaml`**:
  - `minimumReleaseAge` / `blockExoticSubdeps` を**削除**。pnpm 11 でこれらが既定値（1日 / `true`）に昇格したため、明示しなくても同じサプライチェーン保護が効く。
  - `allowBuilds`（`esbuild` / `unrs-resolver` を `false`）を**追加**。pnpm 11 はビルドスクリプトの実行可否が未設定だと警告し、ワークスペースファイルにプレースホルダを自動注入する。両パッケージは pnpm 10 でも `ignoredBuilds`（=未実行）であり、prebuilt バイナリを optional deps で配布するため自前ビルドは不要。`false` で従来挙動を維持する。
  - `nodeLinker: hoisted` は pnpm の既定（`isolated`）ではないため**維持**。

検証: `pnpm-lock.yaml` は全工程で差分なし（解決結果は同一）。`pnpm install --frozen-lockfile`（CI 相当）と `pnpm -r run lint` が成功することをローカルで確認済み。Node.js は v24（pnpm 11 必須の 22+ を満たす）。

### 補足: `allowBuilds` を明記しない場合の挙動

`allowBuilds` を書かなくてもビルドスクリプトが勝手に実行されるわけではない。pnpm 11 の既定はビルドスクリプトを**実行しない（スキップ）**。許可リストに明示された依存のみが実行される。ただし未設定のまま install すると、pnpm 11 は以下を行う:

1. 該当パッケージのビルドスクリプトをスキップ（実行しない）
2. 警告を表示: `[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.8, unrs-resolver@1.9.2`
3. `pnpm-workspace.yaml` に `allowBuilds:` のプレースホルダ（`set this to true or false`）を**自動注入**し、明示的な判断を迫る

| 設定 | ビルドスクリプト | 警告 | ファイル自動注入 |
|---|---|---|---|
| 省略（書かない） | 実行されない | 出る | される |
| `false`（本 PR の設定） | 実行されない | 出ない | されない |
| `true` | 実行される | 出ない | されない |

「実行されるか否か」だけ見れば省略と `false` は同じ（どちらも実行されない）。違いは警告とファイル自動編集の有無のみ。本 PR では CI で毎回警告が出てワークスペースファイルが書き換わるのを防ぐため、`false` を明示している。

## レビューポイント

- `allowBuilds` を `false` にした判断について。従来どおりビルドスクリプトを実行しない安全側の設定で、現状 prebuilt バイナリで動作するため問題ない。将来ネイティブ postinstall を走らせたい場合のみ `true` への変更を検討。
- `minimumReleaseAge` / `blockExoticSubdeps` の削除は「保護の無効化」ではなく「pnpm 11 既定値への委譲」である点（`packageManager` で pnpm 11+ に固定されているため既定が常に適用される）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
