### PR TITLE
feat(a11y): タッチターゲットサイズを最小 48 に拡張 (Button / ListItem)

### DIFF
--- a/apps/sandbox/src/components/button/Button.tsx
+++ b/apps/sandbox/src/components/button/Button.tsx
@@ -26,6 +26,11 @@ export interface ButtonProps {
 }
 
 interface SizeSpec {
+  /**
+   * 最小タッチターゲット (minHeight/minWidth に適用)。全 size で 48 以上を確保しつつ
+   * size ごとに段階化する。padding (内側余白) はこの下限に達しない構成での保険。
+   */
+  minSize: number;
   paddingVertical: number;
   paddingHorizontal: number;
   gap: number;
@@ -34,16 +39,31 @@ interface SizeSpec {
 }
 
 const SIZE_SPECS: Record<ButtonSize, SizeSpec> = {
-  // md は最小タッチターゲット 44pt を満たす (paddingVertical 10 + body lineHeight 24)
-  sm: { paddingVertical: 6, paddingHorizontal: 12, gap: 6, textType: "label", iconSize: 16 },
+  // minSize: sm は最小タッチターゲット 48 を下限に、md 56 / lg 64 へ段階化 (ListItem の 48 とも整合)
+  sm: {
+    minSize: 48,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    gap: 6,
+    textType: "label",
+    iconSize: 16,
+  },
   md: {
+    minSize: 56,
     paddingVertical: 10,
     paddingHorizontal: 16,
     gap: 8,
     textType: "bodyEmphasis",
     iconSize: 18,
   },
-  lg: { paddingVertical: 14, paddingHorizontal: 24, gap: 10, textType: "headline", iconSize: 22 },
+  lg: {
+    minSize: 64,
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    gap: 10,
+    textType: "headline",
+    iconSize: 22,
+  },
 };
 
 interface VariantColors {
@@ -144,6 +164,8 @@ export function Button({
     >
       {({ pressed }) => {
         const containerStyle: ViewStyle = {
+          minHeight: spec.minSize,
+          minWidth: spec.minSize,
           paddingVertical: spec.paddingVertical,
           paddingHorizontal: spec.paddingHorizontal,
           gap: spec.gap,

--- a/apps/sandbox/src/components/grouped-list/ListItem.tsx
+++ b/apps/sandbox/src/components/grouped-list/ListItem.tsx
@@ -7,7 +7,8 @@ import { ThemedText } from "../themed-text/ThemedText";
 
 export const ICON_SLOT_WIDTH = 28;
 export const ICON_GAP = 12;
-const MIN_ROW_HEIGHT = 44;
+// iOS 44pt / Android 48dp のうち厳しい 48 に全 OS 統一 (Button の MIN_TOUCH_TARGET と揃える)
+const MIN_ROW_HEIGHT = 48;
 
 interface CommonItemFields {
   text: ReactNode;


### PR DESCRIPTION
## 概要

アクセシビリティ静的監査 (観点 7 / トラッキング #169) で検出した、タッチターゲットが **iOS 44pt / Android 48dp 未達**の要素を是正する。`hitSlop` で見た目を保つのではなく、ボタン/行の**実寸を底上げ**して推奨サイズを満たす方針 (依頼者確認済み)。

Closes #162

## 変更内容

### Button (`components/button/Button.tsx`)
- `SizeSpec` に size 別の最小タッチターゲット `minSize` を追加し、全 size の子 View に `minHeight` / `minWidth` を設定。
- 実効サイズを**段階化**: **sm 48 / md 56 / lg 64**。最小タッチターゲット 48 を sm の下限に保ちつつ、sm < md < lg の段階差を確保。短ラベル sm の幅も 48 確保。
- padding/gap/textType/iconSize・variant 配色・haptic・accessibility 属性 (#163) は変更なし。

### ListItem (`components/grouped-list/ListItem.tsx`)
- `MIN_ROW_HEIGHT` を **44 → 48** に変更し全 OS 統一 (Button の sm と値を揃える)。disabled 行・遷移行の両方に反映。

### TextLink — 今回は見送り
- RN の `TextProps` には `hitSlop` の型が無く (`Text.d.ts` 0 件)、expo-router の `Link` (= `Omit<TextProps>`) に `hitSlop` を直接渡すと **TypeScript 型エラー**になる。
- かつ TextLink はインライン文中利用も想定されるため、`Pressable` ラップ (block 化) は副作用が大きい。現状 TextLink は未使用。
- **代替案 (将来単独配置で使う場合)**: 呼び出し側で `<Link asChild><Pressable hitSlop={…}>` でラップ、または上下 padding を付与。

## スコープ外
- role / accessibilityLabel 付与 → #163 (完了)
- Icon の label / decorative → #164
- ListItem の行グルーピング・disabled role → #165

## 品質チェック
- `pnpm -r run format` / `pnpm -r run lint` (型チェック込み) 通過
- `pnpm -r run lingui:extract` 実行済み — catalog 差分なし (編集ファイルに翻訳メッセージが無く位置参照が不変)

## 実機検証チェックリスト (マージ前に人間が実施 / #169 ルール)
- [ ] sm / md / lg のサイズ差が視覚的に区別でき、いずれも指で押しやすい (特に短ラベル時の sm)
- [ ] 横並びの sm Button・ListItem 各行で hit 領域が重なって誤タップを誘発しない
- [ ] Android 実機で 48dp 相当が確保される (Accessibility Scanner 併用可)
- [ ] light / dark 両テーマでレイアウト・余白が破綻しない
- [ ] 既存のタップ / 遷移 / 行選択がデグレしていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
