### PR TITLE
feat(a11y): Icon に accessibilityLabel / decorative API を追加し装飾アイコンを隠す

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/components/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/components/index.tsx
@@ -55,7 +55,7 @@ export default function ComponentsScreen(): ReactElement {
           <View style={[styles.iconGrid, { gap: tokens.spacing.lg }]}>
             {ICON_NAMES.map((name) => (
               <View key={name} style={[styles.iconCell, { gap: tokens.spacing.xs }]}>
-                <Icon name={name} size={28} color={tokens.color.text.secondary} />
+                <Icon name={name} size={28} color={tokens.color.text.secondary} decorative />
                 <ThemedText type="caption" tone="tertiary">
                   {name}
                 </ThemedText>

--- a/apps/sandbox/src/app/(tabs)/(home)/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/index.tsx
@@ -19,14 +19,22 @@ export default function Index() {
           text: <Trans>ナビゲーションパターン</Trans>,
           description: <Trans>presentation オプションのデモ</Trans>,
           leadingIcon: (
-            <Ionicons name="layers-outline" size={22} color={tokens.color.text.secondary} />
+            <Ionicons
+              name="layers-outline"
+              size={22}
+              color={tokens.color.text.secondary}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            />
           ),
         },
         {
           href: "/components",
           text: <Trans>コンポーネント</Trans>,
           description: <Trans>Icon / Button / Card など</Trans>,
-          leadingIcon: <Icon name="grid" size={22} color={tokens.color.text.secondary} />,
+          leadingIcon: (
+            <Icon name="grid" size={22} color={tokens.color.text.secondary} decorative />
+          ),
         },
       ],
     },
@@ -39,7 +47,13 @@ export default function Index() {
           text: <Trans>データ取得</Trans>,
           description: <Trans>React Query / fetch サンプル (準備中)</Trans>,
           leadingIcon: (
-            <Ionicons name="cloud-download-outline" size={22} color={tokens.color.text.tertiary} />
+            <Ionicons
+              name="cloud-download-outline"
+              size={22}
+              color={tokens.color.text.tertiary}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            />
           ),
         },
       ],

--- a/apps/sandbox/src/app/(tabs)/settings/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/settings/index.tsx
@@ -37,7 +37,13 @@ export default function SettingsScreen() {
           text: <Trans>テーマ</Trans>,
           description: <Trans>ライト / ダーク / システム</Trans>,
           leadingIcon: (
-            <Ionicons name="contrast-outline" size={22} color={tokens.color.text.secondary} />
+            <Ionicons
+              name="contrast-outline"
+              size={22}
+              color={tokens.color.text.secondary}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            />
           ),
         },
       ],
@@ -54,6 +60,8 @@ export default function SettingsScreen() {
               name="information-circle-outline"
               size={22}
               color={tokens.color.text.tertiary}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
             />
           ),
           trailingBadge: versionBadge,
@@ -62,7 +70,13 @@ export default function SettingsScreen() {
           disabled: true,
           text: <Trans>ライセンス</Trans>,
           leadingIcon: (
-            <Ionicons name="document-text-outline" size={22} color={tokens.color.text.tertiary} />
+            <Ionicons
+              name="document-text-outline"
+              size={22}
+              color={tokens.color.text.tertiary}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            />
           ),
         },
       ],

--- a/apps/sandbox/src/components/button/Button.tsx
+++ b/apps/sandbox/src/components/button/Button.tsx
@@ -178,7 +178,7 @@ export function Button({
         return (
           <View style={[styles.container, containerStyle]}>
             {leadingIcon ? (
-              <Icon name={leadingIcon} size={spec.iconSize} color={colors.text} />
+              <Icon name={leadingIcon} size={spec.iconSize} color={colors.text} decorative />
             ) : null}
             <ThemedText type={spec.textType} tone={colors.textTone}>
               {children}

--- a/apps/sandbox/src/components/icon/Icon.tsx
+++ b/apps/sandbox/src/components/icon/Icon.tsx
@@ -1,7 +1,7 @@
 import { MaterialIcons } from "@react-native-vector-icons/material-icons/static";
 import { SymbolView, type SymbolViewProps, type SymbolWeight } from "expo-symbols";
 import type { ComponentProps, ReactElement } from "react";
-import { Platform, type StyleProp, View, type ViewStyle } from "react-native";
+import { Platform, type StyleProp, View, type ViewProps, type ViewStyle } from "react-native";
 import { useTheme } from "../../theme/useTheme";
 
 // SymbolViewProps["name"] は `SFSymbol | { ios; android; web }` の union。
@@ -44,6 +44,41 @@ export interface IconProps {
   color?: string;
   weight?: SymbolWeight;
   style?: StyleProp<ViewStyle>;
+  /**
+   * 意味を持つアイコン単体の SR 読み上げラベル。`t` マクロ経由（`accessibilityLabel={t`…`}`）で渡す。
+   * 指定すると装飾扱い (`decorative`) より優先され、image 要素として読み上げられる。
+   */
+  accessibilityLabel?: string;
+  /**
+   * 装飾アイコンとして SR から隠す。テキスト併記時のグリフ名二重読み上げを防ぐ。
+   * `accessibilityLabel` と未指定のときは現状どおり a11y 属性を付けない。
+   * @default false
+   */
+  decorative?: boolean;
+}
+
+/**
+ * `accessibilityLabel` / `decorative` から外側 View に載せる a11y 属性を導出する。
+ * label を最優先 (意味アイコン) → decorative (隠す) → どちらも無ければ無指定 (現状維持)。
+ */
+function resolveAccessibilityProps(
+  accessibilityLabel: string | undefined,
+  decorative: boolean,
+): Pick<
+  ViewProps,
+  | "accessible"
+  | "accessibilityLabel"
+  | "accessibilityRole"
+  | "accessibilityElementsHidden"
+  | "importantForAccessibility"
+> {
+  if (accessibilityLabel != null) {
+    return { accessible: true, accessibilityLabel, accessibilityRole: "image" };
+  }
+  if (decorative) {
+    return { accessibilityElementsHidden: true, importantForAccessibility: "no-hide-descendants" };
+  }
+  return {};
 }
 
 /**
@@ -51,15 +86,24 @@ export interface IconProps {
  * Android / Web は Material Icons (`@react-native-vector-icons/material-icons`) にフォールバックする。
  * `GroupedList` の `leadingIcon` や `Button` の icon で再利用する想定。
  */
-export function Icon({ name, size = 24, color, weight, style }: IconProps): ReactElement {
+export function Icon({
+  name,
+  size = 24,
+  color,
+  weight,
+  style,
+  accessibilityLabel,
+  decorative = false,
+}: IconProps): ReactElement {
   const { tokens } = useTheme();
   const resolvedColor = color ?? tokens.color.text.primary;
   const def = ICONS[name];
+  const a11yProps = resolveAccessibilityProps(accessibilityLabel, decorative);
 
   // SymbolView は ViewStyle、MaterialIcons は TextStyle を取り両者の StyleProp は
   // 相互代入できないため、外側の View に ViewStyle を持たせ、グリフ自体は size/color で制御する。
   return (
-    <View style={style}>
+    <View style={style} {...a11yProps}>
       {Platform.OS === "ios" ? (
         <SymbolView
           name={def.sf}

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -93,7 +93,7 @@ msgstr "formSheet"
 msgid "fullScreenModal"
 msgstr "fullScreenModal"
 
-#: src/app/(tabs)/(home)/index.tsx:28
+#: src/app/(tabs)/(home)/index.tsx:34
 msgid "Icon / Button / Card など"
 msgstr "Icon / Button / Card, and more"
 
@@ -182,7 +182,7 @@ msgstr "The presentation style is `modal`, but with `animation` unspecified Andr
 msgid "presentation 形式は modal になるが、画面遷移アニメーションは独立した `animation` プロパティで決まる。`animation` 未指定だと `card` と同じ OS 標準の遷移 (多くは右からスライド) になり、iOS のような「下から上」にはならない。下から上 にしたい場合は `animation: slide_from_bottom` を明示する。ルート Stack に出るので 遷移先ではタブバーが消える。戻るボタン / システムジェスチャーで閉じられる。"
 msgstr "The presentation style becomes `modal`, but the transition animation is controlled separately by the `animation` prop. With `animation` unspecified, it uses the OS-default transition (often slide-in from the right, same as `card`), not the iOS-style \"slide up from the bottom\". Set `animation: slide_from_bottom` explicitly to slide up. Since it sits under the root Stack, the tab bar disappears on the destination screen. Dismissed via the back button or system gesture."
 
-#: src/app/(tabs)/(home)/index.tsx:40
+#: src/app/(tabs)/(home)/index.tsx:48
 msgid "React Query / fetch サンプル (準備中)"
 msgstr "React Query / fetch sample (coming soon)"
 
@@ -271,7 +271,7 @@ msgstr "Icons"
 msgid "アクション"
 msgstr "Action"
 
-#: src/app/(tabs)/settings/index.tsx:51
+#: src/app/(tabs)/settings/index.tsx:57
 msgid "アプリ情報"
 msgstr "App info"
 
@@ -280,7 +280,7 @@ msgid "カード"
 msgstr "Card"
 
 #: src/app/(tabs)/(home)/components/index.tsx:44
-#: src/app/(tabs)/(home)/index.tsx:27
+#: src/app/(tabs)/(home)/index.tsx:33
 msgid "コンポーネント"
 msgstr "Components"
 
@@ -324,7 +324,7 @@ msgstr "Full-screen modal on the in-tab Stack"
 msgid "タブ内 Stack 上の背景透過モーダル"
 msgstr "Transparent modal on the in-tab Stack"
 
-#: src/app/(tabs)/(home)/index.tsx:39
+#: src/app/(tabs)/(home)/index.tsx:47
 msgid "データ取得"
 msgstr "Data fetching"
 
@@ -371,7 +371,7 @@ msgid "ヘッダー左の戻るボタン、または OS のジェスチャーで
 msgstr "Return to the previous screen via the back button in the header or the OS gesture. The tab bar disappearing on the root variant is the differentiator versus the in-tab variant."
 
 #: src/app/(tabs)/_layout.tsx:27
-#: src/app/(tabs)/(home)/index.tsx:51
+#: src/app/(tabs)/(home)/index.tsx:65
 msgid "ホーム"
 msgstr "Home"
 
@@ -379,7 +379,7 @@ msgstr "Home"
 msgid "ボタン"
 msgstr "Button"
 
-#: src/app/(tabs)/settings/index.tsx:63
+#: src/app/(tabs)/settings/index.tsx:71
 msgid "ライセンス"
 msgstr "Licenses"
 
@@ -459,11 +459,11 @@ msgstr "Appearance"
 msgid "実装メモ"
 msgstr ""
 
-#: src/app/(tabs)/settings/index.tsx:46
+#: src/app/(tabs)/settings/index.tsx:52
 msgid "情報"
 msgstr "Info"
 
-#: src/app/(tabs)/(home)/index.tsx:34
+#: src/app/(tabs)/(home)/index.tsx:42
 msgid "準備中"
 msgstr "Coming soon"
 
@@ -500,7 +500,7 @@ msgid "触覚フィードバック"
 msgstr "Haptic feedback"
 
 #: src/app/(tabs)/_layout.tsx:35
-#: src/app/(tabs)/settings/index.tsx:74
+#: src/app/(tabs)/settings/index.tsx:88
 msgid "設定"
 msgstr "Settings"
 

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -103,7 +103,7 @@ msgstr "formSheet"
 msgid "fullScreenModal"
 msgstr "fullScreenModal"
 
-#: src/app/(tabs)/(home)/index.tsx:28
+#: src/app/(tabs)/(home)/index.tsx:34
 msgid "Icon / Button / Card など"
 msgstr "Icon / Button / Card など"
 
@@ -192,7 +192,7 @@ msgstr "presentation 形式は modal だが、Android では animation 未指定
 msgid "presentation 形式は modal になるが、画面遷移アニメーションは独立した `animation` プロパティで決まる。`animation` 未指定だと `card` と同じ OS 標準の遷移 (多くは右からスライド) になり、iOS のような「下から上」にはならない。下から上 にしたい場合は `animation: slide_from_bottom` を明示する。ルート Stack に出るので 遷移先ではタブバーが消える。戻るボタン / システムジェスチャーで閉じられる。"
 msgstr "presentation 形式は modal になるが、画面遷移アニメーションは独立した `animation` プロパティで決まる。`animation` 未指定だと `card` と同じ OS 標準の遷移 (多くは右からスライド) になり、iOS のような「下から上」にはならない。下から上 にしたい場合は `animation: slide_from_bottom` を明示する。ルート Stack に出るので 遷移先ではタブバーが消える。戻るボタン / システムジェスチャーで閉じられる。"
 
-#: src/app/(tabs)/(home)/index.tsx:40
+#: src/app/(tabs)/(home)/index.tsx:48
 msgid "React Query / fetch サンプル (準備中)"
 msgstr "React Query / fetch サンプル (準備中)"
 
@@ -281,7 +281,7 @@ msgstr "アイコン"
 msgid "アクション"
 msgstr "アクション"
 
-#: src/app/(tabs)/settings/index.tsx:51
+#: src/app/(tabs)/settings/index.tsx:57
 msgid "アプリ情報"
 msgstr "アプリ情報"
 
@@ -290,7 +290,7 @@ msgid "カード"
 msgstr "カード"
 
 #: src/app/(tabs)/(home)/components/index.tsx:44
-#: src/app/(tabs)/(home)/index.tsx:27
+#: src/app/(tabs)/(home)/index.tsx:33
 msgid "コンポーネント"
 msgstr "コンポーネント"
 
@@ -334,7 +334,7 @@ msgstr "タブ内 Stack 上の全画面モーダル"
 msgid "タブ内 Stack 上の背景透過モーダル"
 msgstr "タブ内 Stack 上の背景透過モーダル"
 
-#: src/app/(tabs)/(home)/index.tsx:39
+#: src/app/(tabs)/(home)/index.tsx:47
 msgid "データ取得"
 msgstr "データ取得"
 
@@ -381,7 +381,7 @@ msgid "ヘッダー左の戻るボタン、または OS のジェスチャーで
 msgstr "ヘッダー左の戻るボタン、または OS のジェスチャーで前画面に戻る。ルート版ではタブバーが消えるのが in-tab 版との差分。"
 
 #: src/app/(tabs)/_layout.tsx:27
-#: src/app/(tabs)/(home)/index.tsx:51
+#: src/app/(tabs)/(home)/index.tsx:65
 msgid "ホーム"
 msgstr "ホーム"
 
@@ -389,7 +389,7 @@ msgstr "ホーム"
 msgid "ボタン"
 msgstr "ボタン"
 
-#: src/app/(tabs)/settings/index.tsx:63
+#: src/app/(tabs)/settings/index.tsx:71
 msgid "ライセンス"
 msgstr "ライセンス"
 
@@ -469,11 +469,11 @@ msgstr "外観"
 msgid "実装メモ"
 msgstr "実装メモ"
 
-#: src/app/(tabs)/settings/index.tsx:46
+#: src/app/(tabs)/settings/index.tsx:52
 msgid "情報"
 msgstr "情報"
 
-#: src/app/(tabs)/(home)/index.tsx:34
+#: src/app/(tabs)/(home)/index.tsx:42
 msgid "準備中"
 msgstr "準備中"
 
@@ -510,7 +510,7 @@ msgid "触覚フィードバック"
 msgstr "触覚フィードバック"
 
 #: src/app/(tabs)/_layout.tsx:35
-#: src/app/(tabs)/settings/index.tsx:74
+#: src/app/(tabs)/settings/index.tsx:88
 msgid "設定"
 msgstr "設定"
 


### PR DESCRIPTION
Closes #164

アクセシビリティ静的監査（`tasks/accessibility-audit-findings.md` 観点 2）で検出した、`Icon` が装飾アイコンと意味アイコンを区別できない問題に対応する。`accessibilityLabel` / `decorative` API を追加し、装飾アイコンを SR から隠す。共通ルール（#169）に従い、実機 SR 検証は未実施・PR 作成で停止する。

## 変更内容

### `Icon` の API 拡張（破壊変更でない）
- `accessibilityLabel?: string` … 意味アイコン単体用。`t` マクロ経由で渡す前提。指定時は `accessible` + `accessibilityRole="image"` を付与（`decorative` より優先）。
- `decorative?: boolean`（既定 `false`）… 装飾アイコン用。`accessibilityElementsHidden`(iOS) + `importantForAccessibility="no-hide-descendants"`(Android) で SR から隠す。
- **既定挙動**: `accessibilityLabel` も `decorative` も未指定なら現状どおり a11y 属性を付けない（#163 同様、意図を明示する方針）。

### 呼び出し側の装飾化
- `Button.tsx` の `leadingIcon` … children が文言を担うため `decorative`。
- `(home)/components/index.tsx` のショーケース grid … 直下の `name` キャプションが読み上げを担当するため `decorative`。
- `(home)/index.tsx` / `settings/index.tsx` の一覧行 `leadingIcon` … `Icon` の箇所は `decorative`、生 `Ionicons` の箇所は `TextProps` 継承の `accessibilityElementsHidden` / `importantForAccessibility` を直付け。

## スコープの切り分け
- `ListItem.tsx` の chevron と行グルーピング・disabled state は **#165** に委譲（findings 観点 3 = 行グルーピング）。重複編集を避けるため本 PR では触らない。
- `app/(tabs)/_layout.tsx` の `NativeTabs.Trigger.Icon` は対の `Label` が代替テキストを担うため対象外。
- 意味アイコンは現状不在のため新規ラベル文言なし → lingui catalog 差分なし。

## 実機検証チェックリスト（マージ前に人間が実施）
- [x] iOS VoiceOver: 装飾アイコン（Button leadingIcon / 一覧行 leadingIcon / ショーケース grid）が読み上げられない
- [x] Android TalkBack: SF Symbols / Material Icons / Ionicons それぞれで二重読み上げ・グリフ名読みが起きない
- [x] ショーケース画面でアイコンの `name` キャプションのみが読まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)