### PR TITLE
fix(a11y): カラートークンのコントラストを WCAG AA へ是正 (#166)

### DIFF
--- a/apps/sandbox/src/components/button/Button.tsx
+++ b/apps/sandbox/src/components/button/Button.tsx
@@ -172,7 +172,10 @@ export function Button({
           borderRadius: tokens.radius.md,
           backgroundColor: pressed ? colors.backgroundPressed : colors.background,
           ...(colors.border
-            ? { borderWidth: StyleSheet.hairlineWidth, borderColor: colors.border }
+            ? // outline の枠線はボタンの主たる視覚的アフォーダンス。hairlineWidth は
+              // 高密度端末でサブピクセルになり暗背景でかすれるため、1 DIP を確保する
+              // (区切り線用途の hairlineWidth とは要件が異なる)。
+              { borderWidth: 1, borderColor: colors.border }
             : null),
         };
         return (

--- a/apps/sandbox/src/theme/tokens/colors.ts
+++ b/apps/sandbox/src/theme/tokens/colors.ts
@@ -1,6 +1,11 @@
 // WCAG コントラスト比 (light / dark で text vs background):
 // - text.primary (#1A1A1A on #FFFFFF / #FAFAFA on #0B0B0B) ≈ 17.8:1 / 18.5:1 (AAA)
 // - text.secondary on canvas ≈ 6.97:1 / 9.85:1 (AAA)
+// - text.tertiary (n[10]) on canvas ≈ 5.10:1 / 9.08:1 (通常 AA。light は #6E6E6E に調整して達成)
+// - text.disabled (n[9]) on canvas ≈ 3.23:1 / 3.92:1
+//   無効 UI のテキストは WCAG 1.4.3 のコントラスト免除対象だが、視認できる下限として
+//   非テキスト基準 3:1 を満たす段に設定し、tertiary より薄い階層を保つ。
+// - accent.solid 上の onAccent ≈ 4.74:1 / 6.14:1 (solid を a[10] に 1 段濃くして達成)
 // 参考: docs.expo.dev のアクセシビリティガイド / WCAG 2.2
 
 export type ColorScheme = "light" | "dark";
@@ -32,7 +37,7 @@ const lightNeutral: GrayScale = [
   "#D2D2D2",
   "#C0C0C0",
   "#8F8F8F",
-  "#7C7C7C",
+  "#6E6E6E",
   "#5F5F5F",
   "#1A1A1A",
 ];
@@ -141,13 +146,13 @@ const buildSemantic = (n: GrayScale, a: GrayScale): SemanticColorTokens => ({
     primary: n[12],
     secondary: n[11],
     tertiary: n[10],
-    disabled: n[8],
+    disabled: n[9],
     onAccent: n[0],
     link: a[11],
   },
   accent: {
-    solid: a[9],
-    solidHover: a[10],
+    solid: a[10],
+    solidHover: a[11],
     soft: a[2],
     softHover: a[3],
     text: a[11],


### PR DESCRIPTION
## 概要

アクセシビリティ静的監査（観点 5 / `tasks/accessibility-audit-findings.md`）で検出された、WCAG コントラスト比未達のカラートークンを是正する。変更は主に `apps/sandbox/src/theme/tokens/colors.ts` のセマンティックマッピング 3 箇所 + 先頭コメント。加えて実機確認で判明した outline ボタン枠線のかすれ（`Button.tsx` のボーダー幅）も併せて修正する（詳細は後述）。

Closes #166

> ⚠️ **カラートークン変更はテーマ全体に波及するため、マージ前に light/dark 実機での可読性確認が必須**（#169 共通ルール）。本 PR は実装までで停止。

## findings の訂正（重要）

findings / issue 本文の「**dark `accent.solid` 3.74:1**」は `a[8] = #0568D9` で計算した誤り。実際の定義は `solid: a[9] = #0A84FF` で、onAccent（黒文字 `#0B0B0B`）に対し **5.40:1 で AA 達成済み**だった。したがって `accent.solid` は本来 light のみ未達だが、issue 推奨に従い両モードを 1 段濃くして余裕を持たせる。

## 変更内容

| 対象 | 変更 |
|---|---|
| `text.disabled` | `n[8]` → `n[9]` |
| `text.tertiary`（light のみ） | `lightNeutral[10]` `#7C7C7C` → `#6E6E6E`（dark `#B0B0B0` は据え置き） |
| `accent.solid` | `a[9]` → `a[10]` |
| `accent.solidHover` | `a[10]` → `a[11]` |

## コントラスト達成表（変更後）

自前で再計算（WCAG 2.x 相対輝度・しきい値 0.04045）。

| トークン | light | dark | 通常 4.5:1 | 大/非テキスト 3:1 |
|---|---|---|---|---|
| `text.disabled` (n[9]) | 3.23:1（旧 1.77） | 3.92:1（旧 2.19） | ―（1.4.3 免除対象） | ✅ |
| `text.tertiary` (light n[10]→#6E6E6E) | ~5.10:1（旧 4.17） | 9.08:1 | ✅ AA | ✅ |
| `accent.solid` onAccent (a[10]) | 4.74:1（旧 4.02） | 6.14:1（旧 5.40） | ✅ AA(light)/AAA(dark) | ✅ |

- `text.disabled` は WCAG 1.4.3 でコントラスト免除対象（非アクティブ UI）。視認できる下限として非テキスト基準 3:1 を満たす段に設定し、tertiary より薄い階層を保つことで「無効」と判別できるようにした。
- `accent.solidHover` を a[11] に動かしても pressed が solid より濃い(light)/明るい(dark)関係は維持。

## 見た目の影響範囲

- **Button solid**: 背景がやや深い青（両モード）。ラベル可読性向上。
- **Button outline**: border がやや深い青（`accent.solid` 参照）。
- **Button disabled**: ラベル/アイコンが濃くなり判読性向上（薄すぎ解消）。
- **ListItem disabled 行**: 本文/補足テキストが濃く。
- **GroupedList セクションヘッダ(overline)/フッタ(caption)・コンポーネント名ラベル・chevron 等**: tertiary が light で僅かに濃く。
- **legacy `Colors.primary`**（`constants/theme.ts`）: 深い青へ（旧画面に使用箇所があれば波及）。

## 追加修正: outline ボタン枠線のかすれ

実機（ダークテーマ・高密度 Android）で outline ボタンの枠線がかすれて見える事象を確認。原因は色ではなくボーダー幅で、`Button.tsx` が `borderWidth: StyleSheet.hairlineWidth`（= `1 / PixelRatio` ≒ 0.33px）を使っていたためサブピクセルのアンチエイリアスで薄く描画されていた（色トークンの変更で dark の枠線コントラストはむしろ 5.40→6.14:1 に改善している）。

- outline の枠線はボタンの主たる視覚的アフォーダンスのため `borderWidth: 1`（1 DIP）を確保。
- 区切り線用途（`Card` / `GroupedList` / `ListItem` の separator）の `hairlineWidth` は要件が異なるため**据え置き**。
- RN は border-box なのでレイアウトのズレはほぼ無し。disabled outline の枠線も同時にくっきりする。

## 実機検証チェックリスト（マージ前に人間が確認）

- [x] light / dark 実機で文字が読みやすくなった／意図しない見た目変化がない
- [x] solid/soft ボタンのラベルが視認できる
- [x] disabled が「無効」とわかる程度の濃さに収まっている（濃くしすぎて有効に見えない）
- [x] outline / disabled outline の枠線が light / dark でくっきり視認できる（かすれ解消）
- [x] iOS VoiceOver: 既存の role / label / state 読み上げにデグレが無い
- [x] Android TalkBack: 同上
- [x] 既存操作（タップ / 遷移 / 閉じる）がデグレしていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

