### PR TITLE
fix(a11y): フォントスケール耐性 — lineHeight を倍率連動にする

### DIFF
--- a/apps/sandbox/src/components/themed-text/ThemedText.tsx
+++ b/apps/sandbox/src/components/themed-text/ThemedText.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { Text, type TextProps, type TextStyle } from "react-native";
+import { Text, type TextProps, type TextStyle, useWindowDimensions } from "react-native";
 import { Typography, type TypographyTokenName } from "../../theme/tokens/typography";
 import { useTheme } from "../../theme/useTheme";
 
@@ -39,13 +39,22 @@ export function ThemedText({
   ...rest
 }: ThemedTextProps): ReactElement {
   const { tokens } = useTheme();
+  // RN の <Text> は allowFontScaling 既定で fontSize を端末のフォント倍率に追従させるが、
+  // px 指定の lineHeight は追従しない。トークンの lineHeight を倍率 1.0 時の基準値とみなし
+  // 同じ倍率を掛けることで、行間比率を保ったままフォント拡大時の行重なり / クリップを防ぐ。
+  // useWindowDimensions は設定のフォントサイズ変更にリアクティブに追従する。
+  const { fontScale } = useWindowDimensions();
+  const typography = Typography[type];
+  const scaledLineHeight =
+    typography.lineHeight !== undefined ? typography.lineHeight * fontScale : undefined;
 
   const color = tone === "accent" ? tokens.color.accent.text : tokens.color.text[tone];
 
   return (
     <Text
       style={[
-        Typography[type],
+        typography,
+        scaledLineHeight !== undefined ? { lineHeight: scaledLineHeight } : undefined,
         { color },
         weight ? { fontWeight: fontWeightMap[weight] } : undefined,
         align ? { textAlign: align } : undefined,

--- a/apps/sandbox/src/theme/tokens/typography.ts
+++ b/apps/sandbox/src/theme/tokens/typography.ts
@@ -39,6 +39,9 @@ export type TypographyTokenName =
   | "code"
   | "overline";
 
+// lineHeight は端末フォント倍率 1.0 時の基準値。RN の <Text> は allowFontScaling 既定で
+// fontSize を倍率追従させるが px 指定の lineHeight は追従しないため、描画側 (ThemedText) で
+// 同じ倍率を掛けてスケールさせる。トークンを直接 <Text> に渡す場合も同様の対応が要る。
 export const Typography: Record<TypographyTokenName, TextStyle> = {
   displayLg: { fontSize: 34, lineHeight: 40, fontWeight: "700" },
   title: { fontSize: 28, lineHeight: 34, fontWeight: "700" },


### PR DESCRIPTION
## 概要

アクセシビリティ監査（観点 6 / `tasks/accessibility-audit-findings.md`）で検出した、固定 `lineHeight` がフォント拡大時にスケールせず行が重なる / 切れる問題に対応する。

Closes #167

## 方針（選択理由）

**`ThemedText` で `lineHeight` を「基準値 × fontScale」に再計算する**方式を採用した。

- RN の `<Text>` は `allowFontScaling` 既定で `fontSize` を端末のフォント倍率に追従させるが、px 指定の `lineHeight` は追従しない。これが大倍率での行重なり / クリップの原因。
- `useWindowDimensions().fontScale` を掛けて `lineHeight` も同じ倍率で拡大することで、**デザインの行間比率（body 1.5 / caption 1.33 / displayLg 1.18 等）を保ったまま**拡大に追従させる。
  - 「`lineHeight` 指定を外し OS 既定に委ねる」案は、OS 既定（概ね 1.2 前後）に置き換わり caption など詰まった見た目になるため不採用。
- `useWindowDimensions` は設定のフォントサイズ変更にリアクティブに追従する（`PixelRatio.getFontScale()` の静的取得より優れる）。
- 描画に効く `Typography` 利用は `ThemedText` のみ（`Button` / `ListItem` も `ThemedText` 経由）のため、**1 箇所の修正で全テキストに波及**する。
- 固定 `height` は導入せず `minHeight` ベースを維持。`Typography` トークンの `lineHeight` は「倍率 1.0 時の基準値」である旨をコメントで明示した。

## 変更

- `components/themed-text/ThemedText.tsx`: `fontScale` 連動の `lineHeight` 再計算を追加
- `theme/tokens/typography.ts`: `lineHeight` が基準値である旨のコメント追記

## 実機検証チェックリスト（マージ前に人間が確認・必須）

- [ ] iOS: 設定の最大アクセシビリティ文字サイズで行が重ならない / 切れない
- [ ] Android: フォントサイズ 200% で同上
- [ ] `ListItem` の leadingIcon（固定 px）と複数行テキストの縦整合が崩れない
- [ ] `app/(tabs)/(home)/components/index.tsx` の `buttonRow`(flexWrap) が大倍率で破綻しない
- [ ] light / dark 両テーマで確認
- [ ] 既存表示（通常倍率）にデグレがない

🤖 Generated with [Claude Code](https://claude.com/claude-code)