### PR TITLE
chore: .gitignore を最新の Node テンプレートへ更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/settings.local.json
 
+# ===== ここから下は `gh repo gitignore view Node` で生成 =====
 # Logs
 logs
 *.log
@@ -7,7 +8,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
-.pnpm-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -59,12 +59,6 @@ web_modules/
 # Optional stylelint cache
 .stylelintcache
 
-# Microbundle cache
-.rpt2_cache/
-.rts2_cache_cjs/
-.rts2_cache_es/
-.rts2_cache_umd/
-
 # Optional REPL history
 .node_repl_history
 
@@ -76,10 +70,8 @@ web_modules/
 
 # dotenv environment variable files
 .env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
+.env.*
+!.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
@@ -92,6 +84,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+.output
 
 # Gatsby files
 .cache/
@@ -102,9 +95,11 @@ dist
 # vuepress build output
 .vuepress/dist
 
-# vuepress v2.x temp and cache directory
+# vuepress v2.x temp directory
 .temp
-.cache
+
+# Sveltekit cache directory
+.svelte-kit/
 
 # vitepress build output
 **/.vitepress/dist
@@ -124,15 +119,28 @@ dist
 # DynamoDB Local files
 .dynamodb/
 
+# Firebase cache directory
+.firebase/
+
 # TernJS port file
 .tern-port
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
-# yarn v2
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
-.yarn/install-state.gz
+# pnpm
+.pnpm-store
+
+# yarn v3
 .pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
+# Vite files
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+.vite/


### PR DESCRIPTION
## 概要

リポジトリルートの `.gitignore` を `gh repo gitignore view Node` で取得した最新の Node テンプレートに更新しました。独自に追加していた `.claude/settings.local.json` の無視設定はそのまま保持しています。

## 背景・動機

現在の `.gitignore` はリポジトリ作成時の Node デフォルトテンプレート（古いバージョン）がベースになっており、上流テンプレートの更新が反映されていませんでした。最新のエコシステム（pnpm / yarn v3 / Vite など）に対応した無視パターンを取り込むため更新します。

## アプローチ

- 変更履歴を確認し、初期コミット（作成時の Node デフォルト）からの独自変更が先頭の `.claude/settings.local.json` の追加のみであることを特定
- 独自部分を先頭に残し、それ以降を `gh repo gitignore view Node` の最新出力で置き換え
- 生成部分の先頭に `# ===== ここから下は \`gh repo gitignore view Node\` で生成 =====` というコメントマーカーを付与し、手動編集箇所と自動生成箇所を区別できるようにした

### 主な差分

- **追加**: `.env.*` / `\!.env.example`、`.output`、`.svelte-kit/`、`.firebase/`、`# pnpm`(`.pnpm-store`)、`# yarn v3`、`# Vite files`
- **削除（上流テンプレート側の変更）**: `.pnpm-debug.log*`、`# Microbundle cache` 各種、vuepress の重複 `.cache` 行

## レビューポイント

- `.pnpm-debug.log*` が新テンプレートで削除されています。pnpm monorepo のため必要かどうか検討しましたが、新テンプレートのままにする方針としました。