### PR TITLE
fix(sandbox): ホームタブの anchor を index に固定しコールド起動 deeplink での card+fade を防止

### DIFF
--- a/apps/sandbox/src/app/(tabs)/(home)/_layout.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/_layout.tsx
@@ -3,6 +3,13 @@ import { useTheme } from "../../../theme/useTheme";
 import { buildStackScreenOptions } from "../../../theme/navigationScreenOptions";
 import { closeHeaderBackIcon } from "../../../theme/headerCloseIcon";
 
+// anchor（旧 initialRouteName）。コールド起動のディープリンク時のみ効く。
+// このスタックは <Stack.Screen> を明示宣言しているため、anchor を指定しないと
+// 初期ルートが index に固定されず、宣言順の先頭 (card/in-tab-fade) になってしまう。
+// 例: sandbox://tab-b/detail でコールド起動後にホームタブを選ぶと card+fade が出る。
+// anchor: index で index をスタック底に固定し、常にホームへ着地できるようにする。
+export const unstable_settings = { anchor: "index" };
+
 export default function HomeLayout() {
   const { colorScheme, tokens } = useTheme();
 


### PR DESCRIPTION
## 概要

ディープリンクでアプリをコールド起動（例: `sandbox://tab-b/detail`）した後にホームタブを選ぶと、本来のホーム（`index`）ではなく card+fade サンプル（`navigation-patterns/card/in-tab-fade`）が表示される問題を修正します。`(home)` スタックの `unstable_settings` に `anchor: "index"` を追加し、初期ルートを `index` に固定します。

## 背景・動機

`tab-b/detail` などへディープリンクでコールド起動した後にホームタブへ切り替えると、card+fade 画面が出てしまい、本来のホームに着地できませんでした。

### 原因

`(home)` スタックが「**anchor 未指定**」かつ「**`<Stack.Screen>` を JSX で明示宣言し、その先頭が `card/in-tab-fade`、`index` は未宣言**」という構成になっていることが原因です。expo-router 56.2.8 の実装上、次の 3 段の連鎖でホームスタックの初期ルートが `index` ではなく `card/in-tab-fade` になります。

1. **anchor 未指定時に `index` を初期ルートへ補完する処理は存在しない。**
   `getRoutesCore.ts` のデフォルト anchor は「グループ名と同名の子ルート」だけで、`(home)` スタックには該当する子がないため `anchor = undefined` となり `node.initialRouteName` が未設定のままになります。
   （同梱テスト `initialRouteName.test.ios.tsx` の `'push should ignore (group)/index as an initial route if no anchor is specified'` がこの挙動を直接保証しています）

2. **`<Stack.Screen>` を明示宣言すると、その宣言順が優先される。**
   `useScreens` の `getSortedChildren` は宣言済みルートを宣言順で先頭に並べ、`sortRoutes` による「`index` を先頭へ昇格」する特別扱いは**未宣言ルートにしか効きません**。`(home)` は先頭に `card/in-tab-fade` を宣言し `index` は未宣言なので、`routeNames[0]` が `card/in-tab-fade` になります。

3. **ディープリンクのコールド起動では、リンク対象外の並列スタック（ホームタブ）は nested state を持たず、`StackRouter.getInitialState` で `routeNames[0]` に初期化される。**
   `initialRouteName` が undefined のため `routeNames[0]` = `card/in-tab-fade` がそのまま初期ルートになります。

### なぜ tab-a / tab-b では起きないのか

`<Stack.Screen>` を一切宣言しないファイルベース構成（`tab-a` / `tab-b`）では `sortRoutes` が `index` を先頭へ並べるため、結果的に `index` が初期表示になります。`(home)` は明示宣言しているため宣言順が優先され、この「`index` がデフォルト」が成り立ちません。これが `tab-a` の「`index` は既定の初期ルートのため明示自体は冗長」というコメントが `(home)` には当てはまらない理由です。

また `anchor`（旧 `initialRouteName`）の効果は[公式ドキュメント](https://docs.expo.dev/router/advanced/router-settings/)のとおりコールド起動のディープリンク時のみ作用し、アプリ内ナビゲーションでは無視されます。そのため通常起動・アプリ内遷移では `index` が正しく表示され、本事象はコールド起動 deeplink 経由でのみ発生します。

## アプローチ

`tab-a` と同じく `unstable_settings` の `anchor` を `index` に指定しました。これにより linking config に `initialRouteName: "index"` が渡り（上記原因 3 を解消）、スクリーンのソートでも `index` が先頭に固定され（上記原因 2 を解消）、コールド起動 deeplink 時もホームスタックの初期ルートが `index` になります。`(home)` 配下に `index.tsx` が実在するため `anchor: "index"` は正しく解決されます。

- **採用**: `anchor: "index"`。`tab-a` と一貫し、linking config とソートの両面で初期ルートを固定できるため確実。
- **却下**: `index` を先頭の `<Stack.Screen name="index" />` として明示宣言する案。宣言順で直りはするが、anchor 方式の方が意図が明確で `tab-a` と揃う。

## レビューポイント

- 根拠は expo-router 56.2.8 のソース（`getRoutesCore.ts` / `getReactNavigationConfig.ts` / `useScreens.tsx` / `sortRoutes.ts` / 同梱 React Navigation fork の `StackRouter.getInitialState`）および同梱テスト（`initialRouteName.test.ios.tsx`）で確証済みです。lint も通過しています。
- **ランタイム検証は未実施**です。開発ビルドはアプリ固有 deeplink のコールド起動をサポートしない（[Expo ドキュメント](https://docs.expo.dev/develop/development-builds/development-workflows/)に明記）ため、本事象を実機相当で再現するには Release ビルドが必要です。実機での最終確認が必要な場合は `expo run:ios --configuration Release` で検証できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)