### PR TITLE
feat(lingui): 標準 compile フローへ移行し未翻訳の英語で CI を落とす

### DIFF
--- a/.github/workflows/lingui-check.yml
+++ b/.github/workflows/lingui-check.yml
@@ -54,3 +54,6 @@ jobs:
           else
             echo "✅ All translation files are up to date"
           fi
+
+      - name: Check for missing translations (compile --strict)
+        run: pnpm --dir apps/sandbox run lingui:check

--- a/apps/sandbox/.gitignore
+++ b/apps/sandbox/.gitignore
@@ -40,4 +40,9 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
+# Lingui compiled catalogs（.po から生成。install/build 時に再生成）
+src/locales/**/messages.js
+src/locales/**/messages.mjs
+src/locales/**/messages.ts
+
 app-example

--- a/apps/sandbox/.oxfmtrc.json
+++ b/apps/sandbox/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "ignorePatterns": ["build", "coverage"]
+  "ignorePatterns": ["build", "coverage", "src/locales/*/messages.ts"]
 }

--- a/apps/sandbox/.oxlintrc.json
+++ b/apps/sandbox/.oxlintrc.json
@@ -40,5 +40,5 @@
     "builtin": true
   },
   "globals": {},
-  "ignorePatterns": []
+  "ignorePatterns": ["src/locales/*/messages.ts"]
 }

--- a/apps/sandbox/lingui.config.mjs
+++ b/apps/sandbox/lingui.config.mjs
@@ -12,4 +12,5 @@ export default defineConfig({
     },
   ],
   format: formatter(),
+  compileNamespace: "ts",
 });

--- a/apps/sandbox/metro.config.js
+++ b/apps/sandbox/metro.config.js
@@ -1,15 +1,4 @@
+// Learn more https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require("expo/metro-config");
-const config = getDefaultConfig(__dirname);
-const { transformer, resolver } = config;
 
-config.transformer = {
-  ...transformer,
-  babelTransformerPath: require.resolve("@lingui/metro-transformer/expo"),
-};
-
-config.resolver = {
-  ...resolver,
-  sourceExts: [...resolver.sourceExts, "po", "pot"],
-};
-
-module.exports = config;
+module.exports = getDefaultConfig(__dirname);

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -18,6 +18,9 @@
     "format": "oxfmt . --write",
     "generate-types": "expo customize tsconfig.json",
     "lingui:extract": "lingui extract --clean",
+    "lingui:compile": "lingui compile",
+    "lingui:compile-if-needed": "[ -f src/locales/en/messages.ts ] || pnpm run lingui:compile",
+    "lingui:check": "lingui compile --strict",
     "eas-update-cleanup": "eas-update-cleanup"
   },
   "dependencies": {
@@ -63,7 +66,6 @@
     "@lingui/babel-plugin-lingui-macro": "^6.0.0",
     "@lingui/cli": "^6.0.0",
     "@lingui/format-po": "^6.0.0",
-    "@lingui/metro-transformer": "^6.0.0",
     "@testing-library/react-native": "^14.0.0",
     "@types/react": "~19.2.0",
     "eslint": "^9.39.2",

--- a/apps/sandbox/src/i18n.ts
+++ b/apps/sandbox/src/i18n.ts
@@ -1,7 +1,7 @@
 import { i18n } from "@lingui/core";
 import * as Localization from "expo-localization";
-import { messages as jaMessages } from "./locales/ja/messages.po";
-import { messages as enMessages } from "./locales/en/messages.po";
+import { messages as jaMessages } from "./locales/ja/messages";
+import { messages as enMessages } from "./locales/en/messages";
 
 // サポートする言語の定義
 export const locales = {

--- a/apps/sandbox/src/po-types.d.ts
+++ b/apps/sandbox/src/po-types.d.ts
@@ -1,4 +1,0 @@
-declare module "*.po" {
-  import type { Messages } from "@lingui/core";
-  export const messages: Messages;
-}

--- a/docs/lingui/setup.md
+++ b/docs/lingui/setup.md
@@ -20,16 +20,19 @@
 
 | パッケージ | 用途 |
 |-----------|------|
-| `@lingui/cli` | メッセージ抽出コマンド（`lingui extract`） |
+| `@lingui/cli` | メッセージ抽出・コンパイル（`lingui extract` / `lingui compile`） |
+| `@lingui/format-po` | カタログを PO 形式で読み書きするフォーマッタ |
 | `@lingui/babel-plugin-lingui-macro` | マクロをランタイムコードに変換するBabelプラグイン |
-| `@lingui/metro-transformer` | .poファイルをMetro経由で直接インポートするためのTransformer |
 
 ## 設定ファイル
 
-### lingui.config.js
+### lingui.config.mjs
 
 ```javascript
-module.exports = {
+import { defineConfig } from "@lingui/cli";
+import { formatter } from "@lingui/format-po";
+
+export default defineConfig({
   locales: ["ja", "en"],
   sourceLocale: "ja",
   catalogs: [
@@ -39,12 +42,14 @@ module.exports = {
       exclude: ["**/node_modules/**"],
     },
   ],
-  format: "po",
-};
+  format: formatter(),
+  compileNamespace: "ts",
+});
 ```
 
-- `sourceLocale: "ja"`: ソースコード中のテキストは日本語で記述する
-- `format: "po"`: PO形式を採用（Metro Transformerで直接インポート可能）
+- `sourceLocale: "ja"`: ソースコード中のテキストは日本語で記述する（`lingui compile --strict` の未翻訳チェック対象外）
+- `format: formatter()`: カタログは PO 形式（`@lingui/format-po`）
+- `compileNamespace: "ts"`: `lingui compile` の出力を `messages.ts` で生成（ランタイムはこれをインポート）
 
 ### babel.config.js
 
@@ -66,36 +71,27 @@ module.exports = function (api) {
 
 ```javascript
 const { getDefaultConfig } = require("expo/metro-config");
-const config = getDefaultConfig(__dirname);
-const { transformer, resolver } = config;
 
-config.transformer = {
-  ...transformer,
-  babelTransformerPath: require.resolve("@lingui/metro-transformer/expo"),
-};
-
-config.resolver = {
-  ...resolver,
-  sourceExts: [...resolver.sourceExts, "po", "pot"],
-};
-
-module.exports = config;
+module.exports = getDefaultConfig(__dirname);
 ```
 
-Metro Transformerにより `.po` ファイルを直接インポートできる。これにより `lingui compile` が不要になり、ワークフローが簡潔になる。
+デフォルト構成。ランタイムは `lingui compile` が生成した `messages.ts` をインポートする（`.po` は直接インポートしない）。
 
-## Metro Transformer方式
+## コンパイル方式（標準フロー）
 
-本プロジェクトではMetro Transformer方式を採用している。
+本プロジェクトは Lingui 標準の compile フローを採用する（`extract` → 翻訳 → `compile`）。
+ランタイムは `.po` を直接インポートせず、`lingui compile` が生成する `messages.ts`（`compileNamespace: "ts"`）をインポートする。
 
-### 従来方式との比較
+### コンパイル成果物の扱い
 
-| | Metro Transformer（本プロジェクト） | Compile方式（従来） |
-|---|---|---|
-| ワークフロー | `extract` のみ | `extract` → `compile` の2ステップ |
-| .poファイル | 直接インポート | コンパイル後のJSファイルをインポート |
-| ホットリロード | 対応 | コンパイルの再実行が必要 |
-| 導入時期 | Lingui 4.12.0（2024年11月）以降 | 従来から存在 |
+- `apps/sandbox/src/locales/{locale}/messages.ts` は **生成物のため gitignore**（コミットしない）。
+- 生成タイミングは **ルート `package.json` の `postinstall`**（`pnpm --dir apps/sandbox run lingui:compile-if-needed`）に集約。`pnpm install` 時にローカル / CI / EAS いずれでも生成される（gitignore のためチェックアウト直後は必ず不在 → 毎回生成）。
+- 翻訳を変更したら `pnpm --dir apps/sandbox run lingui:compile` で明示的に再生成する。
+- 生成 `messages.ts` は lint/format 対象外（`.oxlintrc.json` / `.oxfmtrc.json` の `ignorePatterns`）。
+
+### 未翻訳の検出（CI ゲート）
+
+`lingui compile --strict`（`lingui:check`）は、`sourceLocale`（`ja`）以外のカタログに未翻訳があると失敗する。`lingui-check.yml` でこれを実行し、英語訳の欠落で CI を落とす。
 
 ## Intl Polyfill設定
 
@@ -181,11 +177,12 @@ import { Trans } from "@lingui/macro";
 
 ## 言語の追加手順
 
-1. `lingui.config.js` の `locales` に言語コードを追加
+1. `lingui.config.mjs` の `locales` に言語コードを追加
 2. `_layout.tsx` に対応するPolyfillのlocale-dataインポートを追加
 3. `src/i18n.ts` の `locales` と `allMessages` に言語を追加
-4. `pnpm -r run lingui:extract` でメッセージカタログを生成
+4. `pnpm -r run lingui:extract` でメッセージカタログ（`.po`）を生成
 5. 生成された `.po` ファイルに翻訳を追加
+6. `pnpm --dir apps/sandbox run lingui:compile` で `messages.ts` を再生成
 
 ## 参考リンク
 

--- a/docs/lingui/workflow.md
+++ b/docs/lingui/workflow.md
@@ -40,14 +40,22 @@
    msgid "ホーム画面へようこそ"
    msgstr "Welcome to Home Screen"
    ```
+   - 英語訳が未入力（空の`msgstr`）のままだとCIが失敗する（後述の`lingui:check`）
 
-4. **動作確認**
+4. **コンパイル成果物の生成**
+   ```bash
+   # .po から messages.ts を再生成（gitignore 対象。ランタイムはこれをインポート）
+   pnpm --dir apps/sandbox run lingui:compile
+   ```
+
+5. **動作確認**
    - デバイスの言語設定を変更して確認
    - iOS: 設定 > 一般 > 言語と地域
    - Android: Settings > System > Languages
 
-5. **コミット**
+6. **コミット**
    ```bash
+   # messages.ts は gitignore のため、コミット対象は .po のみ
    git add apps/sandbox/src/locales
    git commit -m "feat: add home screen translations"
    ```
@@ -96,21 +104,19 @@ import { SelectOrdinal } from "@lingui/react/macro";
 
 プロジェクトには2つのGitHub Actionsワークフローが設定されています：
 
-1. **ci.yml** - 全般的なコード品質チェック
-   - ESLint
-   - Prettier
-   - TypeScript型チェック
-   - **Lingui翻訳チェック**（並列実行）
+1. **ci.yml** - 全般的なコード品質チェック（`lint` / `test` ジョブ）
+   - Lint（Oxlint / expo lint / oxfmt）
+   - テスト（jest）
 
 2. **lingui-check.yml** - 翻訳専用チェック
    - `src/**/*.tsx`、`src/**/*.ts`、`src/**/*.po`の変更時に実行
    - mainブランチへのpush、PR時に自動実行
+   - カタログ同期チェックに加え、`lingui compile --strict` で未翻訳を検出
 
 ### CIチェックの内容
 
-1. `lingui:extract`を実行
-2. 翻訳ファイルに差分がないか確認
-3. 差分があればエラーとして報告
+1. `lingui:extract`を実行し、ソースとカタログ（`.po`）に差分がないか確認（差分があれば失敗）
+2. `lingui:check`（`lingui compile --strict`）を実行し、`en`（`sourceLocale`の`ja`以外）に未翻訳がないか確認（未翻訳があれば失敗）
 
 ### CIが失敗した場合
 
@@ -151,14 +157,14 @@ git add apps/sandbox/src/locales
 git commit -m "chore: update translation files"
 ```
 
-### エラー2: Missing translation for message
+### エラー2: Missing translations（`lingui compile --strict` が失敗）
 
-**原因**: 新規メッセージの英語翻訳が未設定
+**原因**: 新規メッセージの英語翻訳が未設定（空の`msgstr`）。`lingui-check.yml`の`lingui:check`が`Missing N translation(s)`で失敗する。
 
 **解決方法**:
-1. `apps/sandbox/src/locales/en/messages.po`を開く
-2. 空の`msgstr`を見つける
-3. 英語翻訳を追加
+1. ローカルで`pnpm --dir apps/sandbox run lingui:check`を実行し、不足を確認
+2. `apps/sandbox/src/locales/en/messages.po`の空の`msgstr`に英語翻訳を追加
+3. 再度`lingui:check`が通ることを確認（`sourceLocale`の`ja`は検査対象外）
 
 ### エラー3: Duplicate message ID
 
@@ -305,9 +311,11 @@ import { Trans } from "@lingui/macro";
    cat apps/sandbox/src/locales/en/messages.po | grep "検索語"
    ```
 
-3. **Metro Transformerの動作確認**
+3. **コンパイル成果物の再生成 / Metro 再起動**
    ```bash
-   # Metro Bundlerを再起動
+   # .po 変更後に messages.ts を再生成
+   pnpm --dir apps/sandbox run lingui:compile
+   # Metro Bundler を再起動
    pnpm --dir apps/sandbox start --clear
    ```
 
@@ -315,8 +323,7 @@ import { Trans } from "@lingui/macro";
 
 **Q: 翻訳が反映されない**
 A: 以下を確認してください：
-- `lingui:extract`を実行したか
-- 英語翻訳を追加したか
+- `lingui:extract` → 英語翻訳追加 → `lingui:compile` を実行したか
 - Metro Bundlerを再起動したか
 - デバイスの言語設定が正しいか
 
@@ -335,4 +342,4 @@ A: 仕様です。Lingui公式推奨により、モバイルアプリではOSの
 
 ---
 
-最終更新日: 2025-08-15
+最終更新日: 2026-06-24

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "pnpm -r run test"
+    "test": "pnpm -r run test",
+    "postinstall": "pnpm --dir apps/sandbox run lingui:compile-if-needed"
   },
   "keywords": [],
   "author": "",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,6 @@ importers:
       '@lingui/format-po':
         specifier: ^6.0.0
         version: 6.1.0
-      '@lingui/metro-transformer':
-        specifier: ^6.0.0
-        version: 6.1.0(@expo/metro-config@56.0.14(expo@56.0.12)(typescript@6.0.3))(@react-native/metro-babel-transformer@0.85.3(@babel/core@7.29.7))(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))
       '@testing-library/react-native':
         specifier: ^14.0.0
         version: 14.0.0(jest@29.7.0(@types/node@25.9.1))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)(test-renderer@1.2.0(@types/react@19.2.15)(react@19.2.3))
@@ -1250,22 +1247,6 @@ packages:
   '@lingui/message-utils@6.1.0':
     resolution: {integrity: sha512-AYbUVx/1CnLLFHQWAU/ljczknIqepUZuYChcNJCOd/LzFM0jASgXRmzieP156V8EctBXNNIR145rw0HtJ1jmew==}
     engines: {node: '>=22.19.0'}
-
-  '@lingui/metro-transformer@6.1.0':
-    resolution: {integrity: sha512-DW82/VtN7kFHBV5qzOYb6gYLs6rR7jge+Z/ZouKK7P/kusWivza2NS69wgTj+fcMWauqx5Mx4QTEy4nCkKAN/Q==}
-    engines: {node: '>=22.19.0'}
-    peerDependencies:
-      '@expo/metro-config': '*'
-      '@react-native/metro-babel-transformer': '*'
-      expo: '>=50.0.0'
-      react-native: '>=0.73.0'
-    peerDependenciesMeta:
-      '@expo/metro-config':
-        optional: true
-      '@react-native/metro-babel-transformer':
-        optional: true
-      expo:
-        optional: true
 
   '@lingui/react@6.1.0':
     resolution: {integrity: sha512-PKTMyXgIfcmjURONBQmWV7U3IwxWA9gSRqh9gxP2Pr84Kslcyly+4ov7uqJNg/sy3L0qegsjReAXc9bR7Q73Kw==}
@@ -7331,20 +7312,6 @@ snapshots:
       '@messageformat/date-skeleton': 1.1.0
       '@messageformat/parser': 5.1.1
       js-sha256: 0.10.1
-
-  '@lingui/metro-transformer@6.1.0(@expo/metro-config@56.0.14(expo@56.0.12)(typescript@6.0.3))(@react-native/metro-babel-transformer@0.85.3(@babel/core@7.29.7))(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))':
-    dependencies:
-      '@lingui/cli': 6.1.0
-      '@lingui/conf': 6.1.0
-      memoize-one: 6.0.0
-      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3)
-    optionalDependencies:
-      '@expo/metro-config': 56.0.14(expo@56.0.12)(typescript@6.0.3)
-      '@react-native/metro-babel-transformer': 0.85.3(@babel/core@7.29.7)
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.11)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/jest-preset@0.85.3(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.15)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   '@lingui/react@6.1.0(react@19.2.3)':
     dependencies:


### PR DESCRIPTION
## 概要

英語(en)の翻訳が欠けている場合に CI を失敗させる。実現のため `@lingui/metro-transformer` による `.po` 直接 import を廃止し、Lingui 標準の compile フロー（extract → 翻訳 → compile）へ移行した。

## 背景・動機

既存の `lingui-check.yml` は `lingui extract` の差分（ソース ↔ `.po` の同期）しか検証しておらず、`en` に空の `msgstr`（未翻訳）が含まれていても CI は通ってしまっていた。

Lingui で未翻訳を失敗扱いにする公式の組み込み手段は `lingui compile --strict` のみ（`extract` は統計表示だけで exit code に影響しない）。現構成は transformer で `.po` を直接 import し compile を使っていなかったため、この strict チェックが使えなかった。

## アプローチ

- **標準 compile フローへ移行**: ランタイムは `.po` を直接 import せず、`lingui compile`（`compileNamespace: "ts"`）が生成する `messages.ts` を import する。`lingui compile --strict`（`lingui:check`）を CI ゲートに追加し、`sourceLocale`（`ja`）以外＝`en` に未翻訳があれば exit 1 で落とす。
- **成果物は gitignore + install 時生成**: `messages.ts` はコミットせず gitignore し、ルート `package.json` の `postinstall`（`lingui:compile-if-needed`）で生成。pnpm monorepo のためルートに集約し、ローカル / CI / EAS いずれの `pnpm install` でも発火させる。`bluesky-social/social-app` 等の実運用パターンに準拠。
- **検討して見送った案**:
  - transformer を維持したまま CI でだけ `compile --strict` を流す案 → `.po` 直接 import の構成で compile 生成物(.js)を出すのは筋が悪く見送り。
  - 成果物 `messages.ts` をコミットする案 → gitignore 方式（上記）を採用。

### 主な変更

- `lingui.config.mjs`: `compileNamespace: "ts"` 追加
- `metro.config.js`: transformer 設定を撤去（デフォルトへ）／ `src/po-types.d.ts` 削除／ `@lingui/metro-transformer` 依存を除去
- `package.json`: `lingui:compile` / `lingui:compile-if-needed` / `lingui:check` 追加、ルートに `postinstall`
- `.gitignore` に `messages.{js,mjs,ts}`、`.oxlintrc.json` / `.oxfmtrc.json` の `ignorePatterns` に生成 `messages.ts`
- `lingui-check.yml` に `compile --strict` ステップ追加
- `docs/lingui/{setup,workflow}.md` を compile フロー前提へ更新

### 検証結果

- `pnpm install` で `messages.ts` が自動生成（postinstall 発火）
- 未翻訳ゲート: 正常系 exit 0 ／ 異常系（訳を空に）→ exit 1「Missing 1 translation(s)」
- jest 13 件パス、lint/format パス、生成 `messages.ts` は untracked（gitignore 済み）

## レビューポイント

- 成果物生成をルート `postinstall` に集約した点。CI（`ci.yml` の lint/test）は `setup-node` の `pnpm install` 経由で `messages.ts` が生成される想定。
- **EAS Build** は headless 未検証。ルート `postinstall` で生成される想定だが、実ビルドで生成されない場合は `eas-build-post-install` フック追加を検討。
- 現状 `en` は全訳済みのため、本 PR 導入後も CI は緑のまま。
