### PR TITLE
ci: PR ごとに eas build --local (Android) を実行

### DIFF
--- a/.github/workflows/eas-build-local.yml
+++ b/.github/workflows/eas-build-local.yml
@@ -30,13 +30,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
@@ -53,7 +53,7 @@ jobs:
           ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
 
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: success()
         with:
           name: android-build-${{ github.event.pull_request.number }}

--- a/.github/workflows/eas-build-local.yml
+++ b/.github/workflows/eas-build-local.yml
@@ -1,0 +1,59 @@
+name: eas-build-local
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/sandbox/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'package.json'
+      - '.github/workflows/eas-build-local.yml'
+      - '.github/actions/**'
+
+concurrency:
+  group: eas-build-local-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-android:
+    name: EAS Build (Android Local)
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Setup EAS
+        uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android (local)
+        run: eas build --local --profile development --platform android --non-interactive --output ./build-output/sandbox.apk
+        working-directory: apps/sandbox
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: android-build-${{ github.event.pull_request.number }}
+          path: apps/sandbox/build-output/sandbox.apk
+          retention-days: 7

--- a/.github/workflows/eas-build-local.yml
+++ b/.github/workflows/eas-build-local.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Build Android (local)
         run: eas build --local --profile development --platform android --non-interactive --output ./build-output/sandbox.apk
         working-directory: apps/sandbox
+        env:
+          ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

PR ごとに `eas build --local` で Android ローカルビルドを実行し、ネイティブビルドの破損を早期に検知するワークフローを追加する。

## 背景・動機

現在の `eas-build.yml` は手動実行（`workflow_dispatch`）のリモートビルドのみ。ネイティブビルドに影響する変更が PR にあっても、マージ前にビルド可否を検証する手段がなかった。

## アプローチ

- 既存の `eas-build.yml`（手動リモートビルド）とは別に、新規ワークフロー `eas-build-local.yml` を作成
- `preview.yml` と同様のパスフィルター・dependabot 除外パターンを採用
- `concurrency` で同一 PR への push 時に進行中ビルドを自動キャンセル
- `gradle/actions/setup-gradle` で Gradle キャッシュを自動管理
- [Build Speed](https://reactnative.dev/docs/build-speed) に基づき `ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64` でビルド対象アーキテクチャを絞り、ビルド時間を短縮
- ビルド成果物（APK）を 7 日間アーティファクトとして保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)