### PR TITLE
test: PR の E2E を Development Build（Dev Client + Metro 接続）に変更

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,8 +96,10 @@ jobs:
           ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
         run: |
           # emulator をバックグラウンド起動（テスト端末ロケールは既定の en-US を使う）
+          # CI で起動時に SystemUI/Launcher が ANR したため、緩和として RAM とコアを増やす。
           "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" \
-            -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect &
+            -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect \
+            -memory 6144 -cores 4 &
 
           # boot 完了を待つ（最大 5 分）
           adb wait-for-device
@@ -141,6 +143,23 @@ jobs:
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 
+      # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
+      # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）
+      - name: Capture device diagnostics
+        if: always()
+        run: |
+          mkdir -p "$RUNNER_TEMP/diag"
+          adb exec-out screencap -p > "$RUNNER_TEMP/diag/screen.png" 2>/dev/null || true
+          {
+            echo "persist.sys.locale=$(adb shell getprop persist.sys.locale | tr -d '\r')"
+            echo "ro.product.locale=$(adb shell getprop ro.product.locale | tr -d '\r')"
+          } > "$RUNNER_TEMP/diag/locale.txt" 2>/dev/null || true
+          adb shell dumpsys activity activities 2>/dev/null | tr -d '\r' | grep -iE "topResumedActivity|mResumedActivity" > "$RUNNER_TEMP/diag/activity.txt" || true
+          adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1 && adb pull /sdcard/ui.xml "$RUNNER_TEMP/diag/ui.xml" >/dev/null 2>&1 || true
+          echo "=== locale ==="; cat "$RUNNER_TEMP/diag/locale.txt" 2>/dev/null || true
+          echo "=== top activity ==="; cat "$RUNNER_TEMP/diag/activity.txt" 2>/dev/null || true
+          echo "=== UI に表示中のテキスト（抜粋） ==="; grep -oE 'text="[^"]+"' "$RUNNER_TEMP/diag/ui.xml" 2>/dev/null | head -40 || true
+
       # Metro を停止し、ポート転送を解除する（バックグラウンドプロセスの hang 防止）
       - name: Stop Expo / Metro
         if: always()
@@ -150,7 +169,7 @@ jobs:
           pkill -f "expo run:android" 2>/dev/null || true
           pkill -f "expo start" 2>/dev/null || true
 
-      # 成功・失敗にかかわらずレポートとスクショ/録画/ログを保存する
+      # 成功・失敗にかかわらずレポート・スクショ/録画/ログ・診断（画面状態）を保存する
       - name: Upload Maestro artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -160,5 +179,6 @@ jobs:
             maestro-report.xml
             maestro-debug
             ${{ runner.temp }}/expo-run.log
+            ${{ runner.temp }}/diag
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,9 +23,12 @@ env:
   AVD_NAME: e2e
 
 jobs:
-  # Dev Client を含まない e2e プロファイル（JS バンドル埋め込み・Metro 不要）の APK を
-  # eas build --local でビルドし、その APK で Maestro E2E を実行する。
-  # ビルドが通ること自体がネイティブビルド破損の早期検知も兼ねる。
+  # Development Build（Dev Client 入り）を expo run:android でビルド→install→Metro 起動→
+  # アプリ起動まで一括実行し、その上で Maestro E2E を実行する（ローカル開発と同一コマンド）。
+  # E2E_BUILD=true により app.config.ts が dev-client の config plugin を有効化し、
+  # defaultLaunchURL(http://localhost:8081) で launcher を経由せず Metro へ自動接続する。
+  # EAS / EXPO_TOKEN は不要。
+  # Dev Client を含まない（e2e プロファイル / 埋め込み JS）E2E は将来 main/定期実行で行う。
   # 将来 iOS を対象にする場合は e2e-ios ジョブ（macOS ランナー / simulator）を追加する。
   e2e-android:
     name: E2E (Android)
@@ -50,17 +53,6 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
-
-      - name: Setup EAS
-        uses: ./.github/actions/setup-eas
-        with:
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Build Android E2E APK (local)
-        run: eas build --local --profile e2e --platform android --non-interactive --output ./build-output/sandbox-e2e.apk
-        working-directory: apps/sandbox
-        env:
-          ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
 
       - name: Install Maestro CLI
         run: |
@@ -99,6 +91,9 @@ jobs:
             --device "pixel_6"
 
       - name: Run Maestro E2E
+        env:
+          # x86_64 のみビルドして emulator の arch と一致させる（ビルド時間短縮）
+          ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
         run: |
           # emulator をバックグラウンド起動（テスト端末ロケールは既定の en-US を使う）
           "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" \
@@ -127,9 +122,33 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global animator_duration_scale 0
 
-          adb install -r apps/sandbox/build-output/sandbox-e2e.apk
+          # Development Build を expo run:android でビルド→install→Metro 起動→adb reverse→
+          # アプリ起動まで一括実行する（ローカル開発と同一コマンド）。Metro はテスト中ずっと
+          # 生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
+          E2E_BUILD=true pnpm --dir apps/sandbox exec expo run:android > "$RUNNER_TEMP/expo-run.log" 2>&1 &
+          EXPO_RUN_PID=$!
+          echo "EXPO_RUN_PID=$EXPO_RUN_PID" >> "$GITHUB_ENV"
+
+          # ビルド→install→アプリ起動（MainActivity）まで待つ。expo run が途中で死んだら失敗させる
+          timeout 1200 bash -c '
+            until adb shell dumpsys activity activities 2>/dev/null | tr -d "\r" | grep -q "com.yamibeta.sandbox/.MainActivity"; do
+              kill -0 '"$EXPO_RUN_PID"' 2>/dev/null || { echo "expo run:android が予期せず終了しました"; exit 1; }
+              sleep 5
+            done'
+          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）
+          timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
+
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
+
+      # Metro を停止し、ポート転送を解除する（バックグラウンドプロセスの hang 防止）
+      - name: Stop Expo / Metro
+        if: always()
+        run: |
+          adb reverse --remove-all || true
+          kill "$EXPO_RUN_PID" 2>/dev/null || true
+          pkill -f "expo run:android" 2>/dev/null || true
+          pkill -f "expo start" 2>/dev/null || true
 
       # 成功・失敗にかかわらずレポートとスクショ/録画/ログを保存する
       - name: Upload Maestro artifacts
@@ -140,5 +159,6 @@ jobs:
           path: |
             maestro-report.xml
             maestro-debug
+            ${{ runner.temp }}/expo-run.log
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,9 @@ jobs:
   # E2E_BUILD=true により app.config.ts が dev-client の config plugin を有効化し、
   # defaultLaunchURL(http://localhost:8081) で launcher を経由せず Metro へ自動接続する。
   # EAS / EXPO_TOKEN は不要。
+  # ※ アプリ起動時の Metro バンドル生成（CPU スパイク）で低速 emulator の SystemUI/Launcher が ANR
+  #   しないよう、emulator は CI 向け軽量イメージ google_atd を使う（system process が軽く ANR しにくい）。
+  #   コマンドは素の expo run:android のままで、nice や pre-warm 等の小細工は使わない。
   # Dev Client を含まない（e2e プロファイル / 埋め込み JS）E2E は将来 main/定期実行で行う。
   # 将来 iOS を対象にする場合は e2e-ios ジョブ（macOS ランナー / simulator）を追加する。
   e2e-android:
@@ -73,7 +76,7 @@ jobs:
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
             "platform-tools" \
             "emulator" \
-            "system-images;android-${ANDROID_API_LEVEL};google_apis;x86_64" > /dev/null
+            "system-images;android-${ANDROID_API_LEVEL};google_atd;x86_64" > /dev/null
           # adb / emulator を PATH に通す
           echo "$ANDROID_HOME/platform-tools" >> "$GITHUB_PATH"
           echo "$ANDROID_HOME/emulator" >> "$GITHUB_PATH"
@@ -87,7 +90,7 @@ jobs:
           echo "no" | "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" create avd \
             --force \
             --name "$AVD_NAME" \
-            --package "system-images;android-${ANDROID_API_LEVEL};google_apis;x86_64" \
+            --package "system-images;android-${ANDROID_API_LEVEL};google_atd;x86_64" \
             --device "pixel_6"
 
       - name: Run Maestro E2E
@@ -96,7 +99,8 @@ jobs:
           ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
         run: |
           # emulator をバックグラウンド起動（テスト端末ロケールは既定の en-US を使う）
-          # CI で起動時に SystemUI/Launcher が ANR したため、緩和として RAM とコアを増やす。
+          # CI 用の軽量イメージ（google_atd）を使い、アプリ起動時の Metro バンドル生成（CPU スパイク）で
+          # SystemUI/Launcher が ANR するのを抑える。余裕のため RAM/コアも増やす。
           "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" \
             -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect \
             -memory 6144 -cores 4 &
@@ -107,7 +111,7 @@ jobs:
 
           # アプリを日本語表示にするため emulator のロケールを ja-JP に固定する。
           # emulator の -prop では locale を変えられないため、adb root + setprop +
-          # フレームワーク再起動（stop; start）で反映する（google_apis イメージは root 可）。
+          # フレームワーク再起動（stop; start）で反映する（ATD イメージも userdebug で root 可）。
           adb root
           adb wait-for-device
           adb shell "setprop persist.sys.locale ja-JP"

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -5,9 +5,12 @@ appId: com.yamibeta.sandbox
 ---
 - launchApp:
     clearState: true
-# release ビルドの初回起動が遅いことがあるため、最初の要素は長めに待つ
+# clearState 後は Metro からバンドルを再取得するため、「ホーム」が一瞬出た後に再ロードで
+# 空画面を挟むことがある。タイトルだけ待つと後続 assert が空画面で落ちるため、リストが
+# 描画完了した証跡となる項目を extendedWaitUntil で待ってから assert する。
+# （Dev Client は Metro 初回バンドル、非 Dev Client は埋め込み JS の初回起動が遅い）
 - extendedWaitUntil:
-    visible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
-    timeout: 40000
-- assertVisible: "ナビゲーションパターン" # GroupedList の先頭項目
+    visible: "ナビゲーションパターン" # GroupedList の先頭項目（src/app/(tabs)/(home)/index.tsx）
+    timeout: 60000
+- assertVisible: "ホーム" # Stack.Screen.Title / タブラベル
 - assertVisible: "コンポーネント"

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -11,6 +11,6 @@ appId: com.yamibeta.sandbox
 # （Dev Client は Metro 初回バンドル、非 Dev Client は埋め込み JS の初回起動が遅い）
 - extendedWaitUntil:
     visible: "ナビゲーションパターン" # GroupedList の先頭項目（src/app/(tabs)/(home)/index.tsx）
-    timeout: 60000
+    timeout: 120000
 - assertVisible: "ホーム" # Stack.Screen.Title / タブラベル
 - assertVisible: "コンポーネント"

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -1,0 +1,35 @@
+import type { ConfigContext, ExpoConfig } from "expo/config";
+
+// app.json を base に読み込み、E2E ビルド時（E2E_BUILD=true）だけ expo-dev-client の
+// config plugin を追記する dynamic config。通常の expo run / 配布用 dev build
+// （eas.json の development プロファイル）には影響しない。
+//
+// E2E では Dev Client を Metro に自動接続させ、テストを阻害するオーバーレイを抑止する:
+// - defaultLaunchURL: launcher を経由せず直接 Metro へ接続（launchMode=most-recent の
+//   fallback としても効くため clearState 後も再接続する）
+// - skipOnboarding / showMenuAtLaunch / toolsButton: オンボーディング・起動時メニュー・
+//   フローティングツールボタンが assert を阻害しないよう無効化する
+// 詳細は docs/maestro.md を参照。
+export default ({ config }: ConfigContext): ExpoConfig => {
+  const plugins = [...(config.plugins ?? [])];
+
+  if (process.env.E2E_BUILD === "true") {
+    const devClientPlugin: [string, Record<string, unknown>] = [
+      "expo-dev-client",
+      {
+        skipOnboarding: true,
+        showMenuAtLaunch: false,
+        toolsButton: false,
+        defaultLaunchURL: "http://localhost:8081",
+      },
+    ];
+    plugins.push(devClientPlugin);
+  }
+
+  return {
+    ...config,
+    name: config.name ?? "sandbox",
+    slug: config.slug ?? "sandbox",
+    plugins,
+  };
+};

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -5,25 +5,37 @@ Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテ
 
 ## 方針
 
-- **EAS リモートビルドは使わない**。`eas build --local` で GitHub Actions の Linux ランナー上に APK を
-  ビルドするため、EAS のビルドクレジットを消費しない。
-- **Dev Client は使わない**。Dev Client（`developmentClient: true`）の APK は起動時に Metro dev server を
-  探す launcher 画面が出て E2E が不安定になる。代わりに **e2e プロファイル**（`developmentClient: false`、
-  JS バンドル埋め込み）でビルドし、Metro なしで単体起動する APK をテストする。この方式では Dev Client の
-  ツールボタン・オンボーディング・デベロッパーメニューがそもそも表示されないため、無効化のための
-  config plugin は不要。
-- **release ビルドの lint を除外**。`developmentClient: false` は release variant でビルドされ、
-  `lintVitalRelease`（lint）が CI ランナーのメモリを使い切って `OutOfMemoryError` で落ちる。lint は E2E
-  ビルドに不要（品質チェックは oxlint / expo lint で別途実施）なため、`e2e` プロファイルの
-  `android.gradleCommand` を `:app:assembleRelease -x lintVitalRelease` にして lint を除外している。
+- **EAS のビルドクレジットは使わない**。PR は `expo run:android`（GitHub Actions の Linux ランナー上で
+  ローカル gradle ビルド）で完結し、EAS リモートビルドや `EXPO_TOKEN` に依存しない。将来の非 Dev Client 用
+  `e2e` プロファイルのみ `eas build --local` を使う。
+- **PR は Development Build（Dev Client / Metro 接続）でテストする**。ローカル開発（`expo start` +
+  `expo run:ios/android`）と前提を揃え、release ではなく debug ビルドにすることでビルド時間も短縮する。
+  Dev Client（`developmentClient: true`）は本来起動時に Metro dev server を探す launcher 画面が出るが、
+  **`defaultLaunchURL` を焼き込んで Metro へ自動接続**させることで launcher を経由せず起動する。
+- **config plugin の設定は E2E ビルド時のみ適用する**。`apps/sandbox/app.config.ts`（dynamic config）が
+  `E2E_BUILD=true` のときだけ `expo-dev-client` plugin を追記する。これにより通常の `expo run` や配布用
+  dev build（`eas-build.yml` の `development` プロファイル）の開発体験には影響しない。E2E では次を設定:
+  - `defaultLaunchURL: "http://localhost:8081"`: launcher を経由せず直接 Metro へ接続。`launchMode`
+    （既定 `most-recent`）の fallback としても効くため、`clearState` 後の起動でも再接続する。
+  - `skipOnboarding: true` / `showMenuAtLaunch: false` / `toolsButton: false`: オンボーディング・
+    起動時のデベロッパーメニュー・フローティングツールボタンが assert を阻害しないよう無効化する。
+- **フローは Dev Client あり/なしの両対応**。`defaultLaunchURL` による自動接続のおかげで、Maestro フローは
+  単一の `launchApp` で済み、Dev Client あり（自動接続）/ なし（埋め込み JS）の両方が同じフローで通る。
+  Dev Client を含まない E2E（`e2e` プロファイル / release / 埋め込み JS）は将来 main ブランチ or 定期実行で
+  行う想定で、その際も同じフローを再利用する。
+- **release ビルドの lint を除外**（将来の非 Dev Client 用 `e2e` プロファイル）。`developmentClient: false`
+  は release variant でビルドされ、`lintVitalRelease`（lint）が CI ランナーのメモリを使い切って
+  `OutOfMemoryError` で落ちる。lint は E2E ビルドに不要（品質チェックは oxlint / expo lint で別途実施）なため、
+  `e2e` プロファイルの `android.gradleCommand` を `:app:assembleRelease -x lintVitalRelease` にして除外している。
 
 ## 構成ファイル
 
 | ファイル | 役割 |
 | --- | --- |
-| `apps/sandbox/eas.json` の `e2e` プロファイル | E2E 用 APK のビルド設定（Dev Client 無し / release ビルドで lint 除外 / `ios.simulator: true`） |
-| `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム非依存 |
-| `.github/workflows/e2e.yml` | PR ごとに「local build → emulator 起動 → install → maestro test」を1ジョブで実行 |
+| `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）を追記。通常ビルドは `app.json` のまま |
+| `apps/sandbox/eas.json` の `e2e` プロファイル | 将来の非 Dev Client 用 E2E ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
+| `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
+| `.github/workflows/e2e.yml` | PR ごとに「emulator 起動 → `E2E_BUILD=true expo run:android`（build→install→Metro→接続）→ maestro test」を1ジョブで実行 |
 
 ## フローの書き方
 
@@ -36,6 +48,10 @@ appId: com.yamibeta.sandbox
     clearState: true
 - assertVisible: "ホーム"
 ```
+
+Dev Client（E2E ビルド）では `defaultLaunchURL` により `launchApp` だけで Metro へ自動接続するため、
+`openLink` や Dev Client 専用の分岐は不要。同じフローが非 Dev Client ビルドでもそのまま動く。
+launcher 操作などビルド種別に依存する手順をフローに書かないこと（dual-mode を壊さないため）。
 
 ### ロケールに関する注意
 
@@ -51,21 +67,35 @@ assert（`ホーム` / `ナビゲーションパターン` / `コンポーネン
 
 ## ローカルで実行する
 
-事前に **Android SDK / EAS CLI（`npm i -g eas-cli`）/ EAS ログイン（`eas login`）** が必要。
+事前に **Android SDK / Maestro CLI / 起動済み emulator（ロケールは ja-JP 推奨）** が必要。
+Maestro CLI が未インストールなら `curl -fsSL "https://get.maestro.mobile.dev" | bash`。
+
+### Dev Client 経路（PR と同条件・推奨）
+
+`E2E_BUILD=true` を付けて `expo run:android` すると、`app.config.ts` が E2E 用 config plugin を
+有効化した Development Build をビルドし、Metro 起動・install・`adb reverse`・接続まで自動で行う。
+
+```bash
+# 1. E2E 設定の Development Build をビルド・install・Metro 起動（連続稼働）
+E2E_BUILD=true pnpm --dir apps/sandbox exec expo run:android
+
+# 2. 別ターミナルでフローを実行（Dev Client は defaultLaunchURL で Metro に自動接続）
+maestro test apps/sandbox/.maestro/
+```
+
+### 非 Dev Client 経路（将来 main 互換の回帰確認）
+
+EAS CLI（`npm i -g eas-cli`）と EAS ログイン（`eas login`）が必要。
 
 ```bash
 # 1. e2e プロファイルで APK をローカルビルド（Dev Client 無し・Metro 不要）
 pnpm --dir apps/sandbox exec eas build --local --profile e2e --platform android \
   --non-interactive --output ./build-output/sandbox-e2e.apk
 
-# 2. 起動済みの emulator（ロケールは ja-JP 推奨）に APK をインストール
-#    emulator が無ければ別途 `emulator -avd <name>` で起動しておく
+# 2. 起動済みの emulator に install（emulator が無ければ別途 `emulator -avd <name>` で起動）
 adb install -r apps/sandbox/build-output/sandbox-e2e.apk
 
-# 3. Maestro CLI（未インストールなら）
-curl -fsSL "https://get.maestro.mobile.dev" | bash
-
-# 4. フローを実行
+# 3. 同じフローを実行（Metro 不要）
 maestro test apps/sandbox/.maestro/
 ```
 
@@ -74,12 +104,26 @@ maestro test apps/sandbox/.maestro/
 - トリガー: `apps/sandbox/**` などを変更する PR（dependabot は除外）。
 - サードパーティ Action は使わず、GitHub / Gradle / Expo / pnpm の公式 Action と、ubuntu-latest に
   プリインストール済みの Android SDK ツール（`sdkmanager` / `avdmanager` / `emulator` / `adb`）のみで構成。
-- `eas build --local` の APK ABI（`x86_64`）と emulator の `arch` を一致させている。
-- 失敗時も `maestro-report.xml`（JUnit）と `--debug-output` のスクショ/録画/ログを artifact に保存する。
+- emulator 起動・ロケール ja-JP 固定の後、`E2E_BUILD=true expo run:android` を background 起動し、
+  build→install→Metro 起動→`adb reverse`→アプリ起動までを一括で行う（ローカル開発と同一コマンド。
+  EAS / EXPO_TOKEN は不要）。アプリ起動（MainActivity）と Metro readiness を待って maestro を実行し、
+  テスト後は expo run（Metro 含む）を kill する。
+- **ANR 対策に CI 用軽量イメージ `google_atd`（Automated Test Device）を使う**。低速な CI emulator
+  （swiftshader）ではアプリ起動時の初回バンドル生成（CPU スパイク）が emulator を飢えさせ、
+  通常イメージ（`google_apis`）だと SystemUI/Launcher が ANR してテストを阻害する。ATD は不要な
+  システムアプリ/サービスを削った軽量イメージで、同じ CPU スパイク下でもシステムプロセスが応答しやすく
+  ANR しにくい。コマンドは素の `expo run:android` のままで、`nice` や pre-warm 等の小細工は使わない。
+- `ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64` でビルド ABI を emulator の `arch` と一致させている。
+  emulator には `-memory 6144 -cores 4` を付与。
+- 失敗時も `maestro-report.xml`（JUnit）・`--debug-output` のスクショ/録画/ログ・`expo-run.log`・
+  画面診断（スクショ/ロケール/前面 activity/UI テキスト）を artifact に保存する。
 - Maestro CLI は再現性のためバージョン固定（`MAESTRO_VERSION`）。更新は意図的に PR で上げる。
 
 ## iOS を対象に追加する場合
 
-- `e2e` プロファイルは `ios.simulator: true` を持つため、`--platform ios` で simulator 向けにもビルドできる。
-- ワークフローに macOS ランナーの `e2e-ios` ジョブを追加し、`xcrun simctl` で simulator を起動 → `.app` を
-  インストール → `maestro test` を実行する。フロー（`.maestro/*.yaml`）はそのまま再利用できる。
+- Dev Client なら macOS ランナーで `E2E_BUILD=true expo run:ios`（simulator）を使う。非 Dev Client なら
+  `e2e` プロファイル（`ios.simulator: true`）を `eas build --local --platform ios` でビルドする。
+- ワークフローに macOS ランナーの `e2e-ios` ジョブを追加し、simulator を起動 → 上記でビルド/install →
+  `maestro test` を実行する。フロー（`.maestro/*.yaml`）はそのまま再利用できる。
+- iOS simulator は `localhost` が直接ホストを指すため `adb reverse` は不要（`expo run:ios` 経由なら
+  Metro 接続も自動）。`defaultLaunchURL: http://localhost:8081` のまま Metro に接続できる。


### PR DESCRIPTION
## 概要

PR ごとの Maestro E2E を、release ビルド（Dev Client 無し・JS バンドル埋め込み）から **Development Build（Dev Client 入り・Metro 接続）** に変更し、ローカル開発（`expo run`）と前提を揃えます。

## 背景・動機

- ローカルでの E2E は `expo start` + `expo run:ios/android`（Dev Client + Metro 接続）で走らせるため、PR の E2E も同じ前提に揃えたい。
- release ビルド（`assembleRelease` + minify）がビルド時間の主因。Dev Client の debug ビルドは minify が無く短縮が見込める。
- 将来、Dev Client を**含まない**ビルドでの E2E は main / 定期実行で行う想定。そのため Maestro フローは Dev Client あり/なしの両方で動くようにする。

## アプローチ

- **`apps/sandbox/app.config.ts`（dynamic config・新規）**: `E2E_BUILD=true` のときだけ `expo-dev-client` の config plugin を追記。通常の `expo run` や配布用 dev build（`eas-build.yml` の `development` プロファイル）には影響しない。
  - `defaultLaunchURL: http://localhost:8081`: launcher を経由せず Metro へ自動接続。
  - `skipOnboarding: true` / `showMenuAtLaunch: false` / `toolsButton: false`: assert を阻害するオーバーレイを抑止。
- **`eas.json`**: `e2e-dev` プロファイル（`development` 継承 + `env.E2E_BUILD=true`）を追加。非 Dev Client 用の `e2e` プロファイルは将来の main/定期実行向けに残す。
- **`.github/workflows/e2e.yml`**: ビルドを `e2e-dev` に切替。Metro を background 起動（`/status` で readiness 待ち）+ `adb reverse tcp:8081 tcp:8081` + 後始末（Metro kill / reverse 解除）を追加。`metro.log` も artifact 保存。
- **`.maestro/smoke.yaml`**: `clearState` 後の Metro 再バンドルで一瞬空画面になるため、リスト項目を `extendedWaitUntil` で待ってから assert するよう堅牢化。フローは単一の `launchApp` のままで両対応。

### ローカル検証

Android emulator で検証し、CI 相当の条件（フレッシュ install・Metro・`adb reverse`・priming なし・`EXPO_E2E` なしの Metro）で `smoke.yaml` が安定して通ることを確認済み。`defaultLaunchURL` による自動接続が機能し、デベロッパーメニュー/オンボーディング/ツールボタンは表示されないクリーンなホーム画面になることもスクリーンショットで確認。

## レビューポイント

- **CI のビルド方法**: 本コミットは `eas build --local --profile e2e-dev` を使用。これを `pnpm run android`（`expo run:android`）に置き換える案も検討中で、両者の GitHub Actions 実行結果を比較するため後続コミットで切り替えを試す予定（EXPO_TOKEN/EAS 非依存・ローカルと同一コマンドになる一方、ワークフロー構成が変わる）。
- Dev Client の launcher/メニュー挙動は Android では config plugin の効きに癖があり、本 PR の構成（`E2E_BUILD` ビルド + Metro + `adb reverse`）で安定動作することを実機確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
