### PR TITLE
ci: main への push で eas build --local (development) を実行するワークフローを追加

### DIFF
--- a/.github/workflows/eas-build-main.yml
+++ b/.github/workflows/eas-build-main.yml
@@ -1,0 +1,59 @@
+name: eas-build-main
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/sandbox/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'package.json'
+      - '.github/workflows/eas-build-main.yml'
+      - '.github/actions/**'
+
+jobs:
+  # main への push のたびに development プロファイルのローカルネイティブビルドが
+  # 継続して成功することを検証する（eas-build.yml の手動リモートビルドを補完する）。
+  build-android:
+    name: EAS Build --local (development / Android)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Setup EAS
+        uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android (eas build --local, development profile)
+        run: |
+          eas build --local --profile development --platform android \
+            --non-interactive --output ./build-output/sandbox.apk
+        working-directory: apps/sandbox
+
+      - name: Upload build artifact
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sandbox-android-${{ github.sha }}
+          path: apps/sandbox/build-output/sandbox.apk
+          retention-days: 7
+          if-no-files-found: error


### PR DESCRIPTION
## 概要

main への push のたびに `eas build --local --profile development --platform android` を自動実行し、ローカルネイティブビルドが継続して成功することを検証するワークフロー（`.github/workflows/eas-build-main.yml`）を追加する。

## 背景・動機

現状 `development` プロファイルの EAS Build は `eas-build.yml`（手動 `workflow_dispatch` トリガー・EAS リモートビルド）でしか検証されておらず、ローカル（`--local`）でのネイティブビルドは main の変更に対して継続的に検証されていなかった。将来 main ブランチで E2E テストを実行するための前準備でもある。

## アプローチ

- トリガー: push to main。`e2e.yml` と同じパスフィルタ（`apps/sandbox/**` 等）を踏襲
- ステップ構成は `eas-build.yml`（EAS CLI セットアップ）と `e2e.yml`（JDK/Gradle セットアップ）を組み合わせたもの。emulator は起動しないため、`e2e.yml` にある Android SDK の emulator 関連セットアップ（KVM 有効化・system image・AVD 作成）は含めていない
- ビルド成果物（apk）は `upload-artifact` で 7 日間保存し、将来追加する E2E ジョブ等が使い回せるようにする

**却下した代替案・方針変更の経緯:**
- 当初は `apps/sandbox/eas.json` の `e2e` プロファイル（Dev Client なし・Maestro 向けに用意済み）を使う案で計画したが、`development` プロファイルを使うようフィードバックがあり方針変更した。本ワークフローは `e2e` プロファイル / Maestro の文脈とは切り離し、単純な「`development` プロファイルのローカルビルドが壊れていないかの継続検証」として位置づける。そのため `docs/maestro.md` や `e2e.yml` の `e2e` プロファイル関連の記述は変更していない
- `code-reviewer` によるレビューで、`concurrency`（`group: github.ref`, `cancel-in-progress: true`）が「main へのマージ毎に継続してビルド成功を検証する」という目的と矛盾する（連続 push で先行コミットの検証がキャンセルされ、そのコミットの成否が永久に分からなくなる）との指摘を受け、`concurrency` 設定を削除した。同じ push-to-main トリガーの `eas-update.yml` も `concurrency` 制御を持たない設計に倣っている

## レビューポイント

- `secrets.EXPO_TOKEN` を使い main への push のたびに自動でビルドを実行する変更のため、実際に main にマージする前に内容をご確認ください
- `timeout-minutes: 45` は実測データのない暫定値。初回実行後、実際のビルド時間を見て調整を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)