### PR TITLE
docs: accessibility.md の削除済み tasks/ ファイルへのリンクを修正

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -2,10 +2,7 @@
 
 このドキュメントは、`apps/sandbox` でアクセシビリティ（a11y）を維持するための運用ルールをまとめたものです。新規コンポーネントを追加するとき、または既存コンポーネントを変更するときに、スクリーンリーダー（VoiceOver / TalkBack）対応を最初から正しく組み込めるよう、**実際に確定した規約とコードパターン**を示します。
 
-ここに載るパターンは机上のものではなく、監査・改善（tracking [#169](https://github.com/yami-beta/expo-sandbox/issues/169)）の Phase 1〜3（PR #171〜#176・CLOSED #167）で実コードに反映された規約です。背景・監査結果は次を参照してください。
-
-- 監査タスク: [`tasks/accessibility-audit.md`](../tasks/accessibility-audit.md)
-- 静的監査 findings（9 観点・対象 56 ファイル）: [`tasks/accessibility-audit-findings.md`](../tasks/accessibility-audit-findings.md)
+ここに載るパターンは机上のものではなく、監査・改善（tracking [#169](https://github.com/yami-beta/expo-sandbox/issues/169)）の Phase 1〜3（PR #171〜#176・CLOSED #167）で実コードに反映された規約です。監査タスク（静的監査 findings・9 観点・対象 56 ファイル）は完了済みのため PR #200 で削除されており、9 観点は[観点別チェックリスト](#観点別チェックリスト監査-9-観点)に転記済みです。
 
 ## 目次
 
@@ -305,7 +302,7 @@ React Native は `allowFontScaling`（既定 `true`）のとき、`lineHeight`�
 
 ## 観点別チェックリスト（監査 9 観点）
 
-[`tasks/accessibility-audit-findings.md`](../tasks/accessibility-audit-findings.md) の 9 観点を踏襲した、レビュー時の確認項目です。
+監査 findings（完了済みのため PR #200 で削除）の 9 観点を踏襲した、レビュー時の確認項目です。
 
 1. **タッチ可能要素のラベル**: すべてのタッチ要素に `accessibilityRole` があるか（`Link` 配下を除く）。アイコンのみのボタンに `accessibilityLabel`（`t` マクロ経由）があるか。透明な hit-area は隠せているか。
 2. **画像・アイコンの代替テキスト**: 意味アイコンに `accessibilityLabel`、装飾アイコンに装飾隠しの定型があるか。
@@ -341,6 +338,6 @@ PR 本文に次のチェックリストを記載します（[#169](https://githu
 - [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
 - [iOS Human Interface Guidelines - Accessibility](https://developer.apple.com/design/human-interface-guidelines/accessibility)
 - [Android Accessibility](https://developer.android.com/guide/topics/ui/accessibility)
-- 内部: [`tasks/accessibility-audit.md`](../tasks/accessibility-audit.md) / [`tasks/accessibility-audit-findings.md`](../tasks/accessibility-audit-findings.md) / [`docs/lingui/workflow.md`](./lingui/workflow.md)
+- 内部: [`docs/lingui/workflow.md`](./lingui/workflow.md)（監査タスクは完了済みのため PR #200 で削除。9 観点は[観点別チェックリスト](#観点別チェックリスト監査-9-観点)を参照）
 
-最終更新日: 2026-06-05
+最終更新日: 2026-07-03


### PR DESCRIPTION
## 概要

`docs/accessibility.md` 内に残っていた、削除済みの `tasks/accessibility-audit.md` / `tasks/accessibility-audit-findings.md` へのリンク切れを修正する。

## 背景・動機

両ファイルは監査完了済みとして 371dd24（PR #200）で削除されていたが、`docs/accessibility.md` に3箇所リンクが残っておりリンク切れになっていた。PR #202 の code-reviewer レビューで検出され、main 由来の既存 stale としてスコープ外のため issue #204 として切り出されていたもの。

該当箇所:

- `docs/accessibility.md:7-8`（現行 5行目） — 冒頭の関連資料リンク
- `docs/accessibility.md:308`（現行 305行目） — 「findings の 9 観点を踏襲した」の参照
- `docs/accessibility.md:344`（現行 341行目） — 末尾の内部リンク集

## アプローチ

issue の対応案のうち「リンクを削除し、完了済み（PR #200 で削除）の注記に置き換える」を採用した。9 観点の内容自体は同ファイル内の「観点別チェックリスト（監査9観点）」セクションに既に転記済みだったため、削除ファイルへのリンクではなくそのセクションへの内部リンクに差し替えている。

## レビューポイント

- 注記の文言・置き換え先リンクが自然か

Closes #204