### PR TITLE
ci(e2e): expo run:android にネイティブビルドキャッシュを導入

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,16 +76,18 @@ jobs:
         uses: ./.github/actions/setup-node
 
       # TODO(debug, remove before merge): 別々の CI 実行でネイティブフィンガープリントが
-      # 一致しない原因調査のため、ソース単位のハッシュをダンプする。
-      - name: DEBUG dump fingerprint sources
+      # 一致しない原因調査のため、ビルド前後でソース単位のハッシュをダンプする。
+      # expo run:android の内部呼び出し（build-cache-providers/index.js）は platforms を
+      # 指定せず createFingerprintAsync を呼ぶため、ここでも指定しない（挙動を忠実に再現する）。
+      - name: DEBUG dump fingerprint (before build)
         run: |
           cd apps/sandbox
-          E2E_BUILD=true pnpm exec expo prebuild --platform android --no-install
+          E2E_BUILD=true pnpm exec expo prebuild --platform android
           E2E_BUILD=true node -e "
             const Fingerprint = require(require.resolve('@expo/fingerprint', { paths: [process.cwd()] }));
-            Fingerprint.createFingerprintAsync(process.cwd(), { platforms: ['android'], debug: true }).then(fp => {
-              console.log('DEBUG_HASH:', fp.hash);
-              require('fs').writeFileSync(process.env.RUNNER_TEMP + '/fingerprint-debug.json', JSON.stringify(fp, null, 2));
+            Fingerprint.createFingerprintAsync(process.cwd(), { debug: true }).then(fp => {
+              console.log('DEBUG_HASH_BEFORE:', fp.hash);
+              require('fs').writeFileSync(process.env.RUNNER_TEMP + '/fingerprint-debug-before.json', JSON.stringify(fp, null, 2));
             });
           "
 
@@ -177,6 +179,20 @@ jobs:
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 
+      # TODO(debug, remove before merge): ビルド後のフィンガープリントをダンプする
+      # （before と比較し、ビルド自体がフィンガープリント対象ファイルを変化させていないか確認する）。
+      - name: DEBUG dump fingerprint (after build)
+        if: always()
+        run: |
+          cd apps/sandbox
+          E2E_BUILD=true node -e "
+            const Fingerprint = require(require.resolve('@expo/fingerprint', { paths: [process.cwd()] }));
+            Fingerprint.createFingerprintAsync(process.cwd(), { debug: true }).then(fp => {
+              console.log('DEBUG_HASH_AFTER:', fp.hash);
+              require('fs').writeFileSync(process.env.RUNNER_TEMP + '/fingerprint-debug-after.json', JSON.stringify(fp, null, 2));
+            });
+          "
+
       # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
       # grep パターンは node_modules/@expo/local-build-cache-provider・
       # node_modules/@expo/cli の実際のログ文言に基づく。
@@ -233,6 +249,7 @@ jobs:
             maestro-debug
             ${{ runner.temp }}/expo-run.log
             ${{ runner.temp }}/diag
-            ${{ runner.temp }}/fingerprint-debug.json
+            ${{ runner.temp }}/fingerprint-debug-before.json
+            ${{ runner.temp }}/fingerprint-debug-after.json
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,27 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
 
+      # TODO(debug, remove before merge): masked-view の AndroidManifest.xml が
+      # 「いつ」書き換わるのかを特定するため、pnpm install 直後（このステップ）と
+      # prebuild 直後の内容をスナップショットする。ビルド後のスナップショットは
+      # 「Run Maestro E2E」の直後で取る。
+      - name: DEBUG snapshot masked-view manifest (after install)
+        run: |
+          MV="node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml"
+          echo "=== after install ==="
+          cat "$MV" || echo "(not found)"
+          sha256sum "$MV" || true
+
+      - name: DEBUG snapshot masked-view manifest (after prebuild)
+        run: |
+          cd apps/sandbox
+          E2E_BUILD=true pnpm exec expo prebuild --platform android
+          cd ../..
+          MV="node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml"
+          echo "=== after prebuild ==="
+          cat "$MV" || echo "(not found)"
+          sha256sum "$MV" || true
+
       - name: Install Maestro CLI
         run: |
           curl -fsSL "https://get.maestro.mobile.dev" | bash
@@ -162,6 +183,15 @@ jobs:
 
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
+
+      # TODO(debug, remove before merge): ビルド後のスナップショット。
+      - name: DEBUG snapshot masked-view manifest (after build)
+        if: always()
+        run: |
+          MV="node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml"
+          echo "=== after build ==="
+          cat "$MV" || echo "(not found)"
+          sha256sum "$MV" || true
 
       # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
       # grep パターンは node_modules/@expo/local-build-cache-provider・

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
       # ネイティブ変更後も更新されなくなるため。異なる fingerprint のエントリは自動削除されず
       # ディレクトリは増え続けるが、GitHub 側の自動退役に任せる（docs/maestro.md 参照）。
       - name: Restore native build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: apps/sandbox/.expo/build-cache
           key: e2e-android-buildcache-${{ github.run_id }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,20 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
 
+      # TODO(debug, remove before merge): 別々の CI 実行でネイティブフィンガープリントが
+      # 一致しない原因調査のため、ソース単位のハッシュをダンプする。
+      - name: DEBUG dump fingerprint sources
+        run: |
+          cd apps/sandbox
+          E2E_BUILD=true pnpm exec expo prebuild --platform android --no-install
+          E2E_BUILD=true node -e "
+            const Fingerprint = require(require.resolve('@expo/fingerprint', { paths: [process.cwd()] }));
+            Fingerprint.createFingerprintAsync(process.cwd(), { platforms: ['android'], debug: true }).then(fp => {
+              console.log('DEBUG_HASH:', fp.hash);
+              require('fs').writeFileSync(process.env.RUNNER_TEMP + '/fingerprint-debug.json', JSON.stringify(fp, null, 2));
+            });
+          "
+
       - name: Install Maestro CLI
         run: |
           curl -fsSL "https://get.maestro.mobile.dev" | bash
@@ -219,5 +233,6 @@ jobs:
             maestro-debug
             ${{ runner.temp }}/expo-run.log
             ${{ runner.temp }}/diag
+            ${{ runner.temp }}/fingerprint-debug.json
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,22 +75,6 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
 
-      # TODO(debug, remove before merge): 別々の CI 実行でネイティブフィンガープリントが
-      # 一致しない原因調査のため、ビルド前後でソース単位のハッシュをダンプする。
-      # expo run:android の内部呼び出し（build-cache-providers/index.js）は platforms を
-      # 指定せず createFingerprintAsync を呼ぶため、ここでも指定しない（挙動を忠実に再現する）。
-      - name: DEBUG dump fingerprint (before build)
-        run: |
-          cd apps/sandbox
-          E2E_BUILD=true pnpm exec expo prebuild --platform android
-          E2E_BUILD=true node -e "
-            const Fingerprint = require(require.resolve('@expo/fingerprint', { paths: [process.cwd()] }));
-            Fingerprint.createFingerprintAsync(process.cwd(), { debug: true }).then(fp => {
-              console.log('DEBUG_HASH_BEFORE:', fp.hash);
-              require('fs').writeFileSync(process.env.RUNNER_TEMP + '/fingerprint-debug-before.json', JSON.stringify(fp, null, 2));
-            });
-          "
-
       - name: Install Maestro CLI
         run: |
           curl -fsSL "https://get.maestro.mobile.dev" | bash
@@ -179,20 +163,6 @@ jobs:
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 
-      # TODO(debug, remove before merge): ビルド後のフィンガープリントをダンプする
-      # （before と比較し、ビルド自体がフィンガープリント対象ファイルを変化させていないか確認する）。
-      - name: DEBUG dump fingerprint (after build)
-        if: always()
-        run: |
-          cd apps/sandbox
-          E2E_BUILD=true node -e "
-            const Fingerprint = require(require.resolve('@expo/fingerprint', { paths: [process.cwd()] }));
-            Fingerprint.createFingerprintAsync(process.cwd(), { debug: true }).then(fp => {
-              console.log('DEBUG_HASH_AFTER:', fp.hash);
-              require('fs').writeFileSync(process.env.RUNNER_TEMP + '/fingerprint-debug-after.json', JSON.stringify(fp, null, 2));
-            });
-          "
-
       # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
       # grep パターンは node_modules/@expo/local-build-cache-provider・
       # node_modules/@expo/cli の実際のログ文言に基づく。
@@ -249,7 +219,5 @@ jobs:
             maestro-debug
             ${{ runner.temp }}/expo-run.log
             ${{ runner.temp }}/diag
-            ${{ runner.temp }}/fingerprint-debug-before.json
-            ${{ runner.temp }}/fingerprint-debug-after.json
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,13 +55,15 @@ jobs:
       # 成長型キャッシュとする。固定キーだと actions/cache の「完全一致時は保存しない」仕様により
       # ネイティブ変更後も更新されなくなるため。異なる fingerprint のエントリは自動削除されず
       # ディレクトリは増え続けるが、GitHub 側の自動退役に任せる（docs/maestro.md 参照）。
+      # TODO(debug, remove before merge): key prefix を一時的に変え、既存キャッシュを
+      # 削除せずに今回の実行だけ確実にキャッシュミス（フルビルド）させる。
       - name: Restore native build cache
         uses: actions/cache@v4
         with:
           path: apps/sandbox/.expo/build-cache
-          key: e2e-android-buildcache-${{ github.run_id }}
+          key: e2e-android-buildcache-debug-manifest-${{ github.run_id }}
           restore-keys: |
-            e2e-android-buildcache-
+            e2e-android-buildcache-debug-manifest-
 
       - name: Setup JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,9 @@ jobs:
   # E2E_BUILD=true により app.config.ts が dev-client の config plugin を有効化し、
   # defaultLaunchURL(http://localhost:8081) で launcher を経由せず Metro へ自動接続する。
   # EAS / EXPO_TOKEN は不要。
+  # ネイティブフィンガープリントが前回と一致する場合は expo run:android 自体が
+  # Gradle ビルドをスキップしてキャッシュ済みバイナリを再利用する
+  # （apps/sandbox/app.config.ts の buildCacheProvider、下記 actions/cache で永続化）。
   # ※ アプリ起動時の Metro バンドル生成（CPU スパイク）で低速 emulator の SystemUI/Launcher が ANR
   #   しないよう、emulator は CI 向け軽量イメージ google_atd を使う（system process が軽く ANR しにくい）。
   #   コマンドは素の expo run:android のままで、nice や pre-warm 等の小細工は使わない。
@@ -44,6 +47,21 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      # expo run:android のネイティブビルドキャッシュ（apps/sandbox/app.config.ts の
+      # buildCacheProvider）が使うディレクトリを永続化する。fingerprint が前回と一致すれば
+      # expo run:android が Gradle ビルドをスキップしてこの中のバイナリを再利用する。
+      # key は常にユニーク（run_id）にし restore-keys で直近のキャッシュを復元する
+      # 成長型キャッシュとする。固定キーだと actions/cache の「完全一致時は保存しない」仕様により
+      # ネイティブ変更後も更新されなくなるため。異なる fingerprint のエントリは自動削除されず
+      # ディレクトリは増え続けるが、GitHub 側の自動退役に任せる（docs/maestro.md 参照）。
+      - name: Restore native build cache
+        uses: actions/cache@v4
+        with:
+          path: apps/sandbox/.expo/build-cache
+          key: e2e-android-buildcache-${{ github.run_id }}
+          restore-keys: |
+            e2e-android-buildcache-
 
       - name: Setup JDK
         uses: actions/setup-java@v5
@@ -144,6 +162,23 @@ jobs:
 
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
+
+      # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
+      # grep パターンは node_modules/@expo/local-build-cache-provider・
+      # node_modules/@expo/cli の実際のログ文言に基づく。
+      - name: Summarize native build cache result
+        if: always()
+        run: |
+          LOG="$RUNNER_TEMP/expo-run.log"
+          if [ ! -f "$LOG" ]; then
+            echo "### Native build cache: expo-run.log が見つかりません" >> "$GITHUB_STEP_SUMMARY"
+          elif grep -qE 'Installing .*\.expo/build-cache/' "$LOG"; then
+            echo "### Native build cache: HIT（ネイティブビルドをスキップ）" >> "$GITHUB_STEP_SUMMARY"
+          elif grep -q 'Copying build to local cache' "$LOG"; then
+            echo "### Native build cache: MISS（フルビルド実行 → 今回の成果をキャッシュに追加）" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Native build cache: 判定不能（expo-run.log を確認）" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
       # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,15 +55,13 @@ jobs:
       # 成長型キャッシュとする。固定キーだと actions/cache の「完全一致時は保存しない」仕様により
       # ネイティブ変更後も更新されなくなるため。異なる fingerprint のエントリは自動削除されず
       # ディレクトリは増え続けるが、GitHub 側の自動退役に任せる（docs/maestro.md 参照）。
-      # TODO(debug, remove before merge): key prefix を一時的に変え、既存キャッシュを
-      # 削除せずに今回の実行だけ確実にキャッシュミス（フルビルド）させる。
       - name: Restore native build cache
         uses: actions/cache@v4
         with:
           path: apps/sandbox/.expo/build-cache
-          key: e2e-android-buildcache-debug-manifest-${{ github.run_id }}
+          key: e2e-android-buildcache-${{ github.run_id }}
           restore-keys: |
-            e2e-android-buildcache-debug-manifest-
+            e2e-android-buildcache-
 
       - name: Setup JDK
         uses: actions/setup-java@v5
@@ -76,27 +74,6 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
-
-      # TODO(debug, remove before merge): masked-view の AndroidManifest.xml が
-      # 「いつ」書き換わるのかを特定するため、pnpm install 直後（このステップ）と
-      # prebuild 直後の内容をスナップショットする。ビルド後のスナップショットは
-      # 「Run Maestro E2E」の直後で取る。
-      - name: DEBUG snapshot masked-view manifest (after install)
-        run: |
-          MV="node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml"
-          echo "=== after install ==="
-          cat "$MV" || echo "(not found)"
-          sha256sum "$MV" || true
-
-      - name: DEBUG snapshot masked-view manifest (after prebuild)
-        run: |
-          cd apps/sandbox
-          E2E_BUILD=true pnpm exec expo prebuild --platform android
-          cd ../..
-          MV="node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml"
-          echo "=== after prebuild ==="
-          cat "$MV" || echo "(not found)"
-          sha256sum "$MV" || true
 
       - name: Install Maestro CLI
         run: |
@@ -185,15 +162,6 @@ jobs:
 
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
-
-      # TODO(debug, remove before merge): ビルド後のスナップショット。
-      - name: DEBUG snapshot masked-view manifest (after build)
-        if: always()
-        run: |
-          MV="node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml"
-          echo "=== after build ==="
-          cat "$MV" || echo "(not found)"
-          sha256sum "$MV" || true
 
       # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
       # grep パターンは node_modules/@expo/local-build-cache-provider・

--- a/apps/sandbox/.fingerprintignore
+++ b/apps/sandbox/.fingerprintignore
@@ -1,0 +1,6 @@
+# @react-native-masked-view/masked-view の AndroidManifest.xml は Gradle ビルド時に
+# AGP8 互換のため package 属性が取り除かれる形で書き換えられる（ビルド前後で内容が変わる）。
+# @expo/fingerprint がこれを検出すると、ビルド前（resolveBuildCache）とビルド後
+# （uploadBuildCache）でフィンガープリントが一致せず、ネイティブビルドキャッシュが
+# 常に MISS になってしまうため除外する。
+**/node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml

--- a/apps/sandbox/.fingerprintignore
+++ b/apps/sandbox/.fingerprintignore
@@ -1,6 +1,27 @@
-# @react-native-masked-view/masked-view の AndroidManifest.xml は Gradle ビルド時に
-# AGP8 互換のため package 属性が取り除かれる形で書き換えられる（ビルド前後で内容が変わる）。
-# @expo/fingerprint がこれを検出すると、ビルド前（resolveBuildCache）とビルド後
-# （uploadBuildCache）でフィンガープリントが一致せず、ネイティブビルドキャッシュが
-# 常に MISS になってしまうため除外する。
+# --- @react-native-masked-view/masked-view の AndroidManifest.xml ---
+#
+# 症状: ネイティブビルドキャッシュ（apps/sandbox/app.config.ts の buildCacheProvider）が
+# 常に MISS になり、キャッシュが一切効かない。
+#
+# 原因: このファイルは Gradle ビルド実行中に書き換わる（pnpm install 直後・
+# expo prebuild 直後の内容は同一で、Gradle ビルド後にだけ変化することを実際の CI 実行で
+# 確認済み）。具体的には `package="org.reactnative.maskedview"` 属性が取り除かれ、
+# 跡地に二重スペースが残る（<manifest  xmlns:android=...> ）。XML をパースして
+# 書き直したのではなく単純な文字列置換の痕跡で、このモジュールに対して実行される
+# Gradle タスクはすべて AGP（Android Gradle Plugin）標準の組み込みタスクのみだった
+# （Expo/RN 独自のカスタムタスクは無かった）ことから、AGP 自身（あるいは Gradle の
+# ビルドキャッシュ機構）による挙動と推測される。正確な実装箇所は AGP がクローズド
+# ソースのため特定できていない。
+#
+# @expo/fingerprint はビルド前（resolveBuildCache）とビルド後（uploadBuildCache）の
+# 2回、別々にこのファイルを含むフィンガープリントを計算する。書き換えが起きるため
+# 同一コミット・同一実行内でもこの2回の値が一致せず、過去にアップロードされた
+# キャッシュには原理的に絶対ヒットしない。
+#
+# 補足: @react-native-masked-view/masked-view は Expo 公式パッケージではなく、
+# expo-router が内部にバンドルしている React Navigation 由来の画面遷移コンポーネント
+# （expo-router/build/react-navigation/elements/）が使うサードパーティパッケージ。
+# 原因が判明している expo-* パッケージ群には同様の差分は見られなかった。
+#
+# 対処: このファイルをフィンガープリント対象から除外し、内容の変化を無視する。
 **/node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -1,4 +1,7 @@
 # アプリ起動〜ホーム画面の表示を確認する最小スモークテスト。
+# このフローへの変更はネイティブ部分（依存関係・ネイティブコード・config plugin・app.json/
+# app.config の設定）を伴わないため、CI のネイティブビルドキャッシュ（docs/maestro.md 参照）が
+# ヒットし expo run:android の Gradle ビルドがスキップされる想定。
 # emulator ロケールは固定せず（既定 en-US）、E2E ビルドはアプリの言語既定値を ja に固定する
 # （E2E_DEFAULT_LOCALE=ja / .github/workflows/e2e.yml・src/i18n/locale.ts 参照）。
 # 表示テキストは lingui の <Trans>（sourceLocale=ja）。

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -15,6 +15,11 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 // バイナリを再利用させる。CI（e2e.yml）側で actions/cache によりこのディレクトリを永続化する。
 // 値は必ずオブジェクト形式で指定すること（生文字列は @expo/cli が
 // "Invalid build cache provider" として拒否する）。
+// plugin の "expo/local-build-cache-provider" は expo パッケージが公開しているサブパス
+// （node_modules/expo/local-build-cache-provider.js。実体は @expo/local-build-cache-provider
+// への re-export）。スコープ付きパッケージ名 "@expo/local-build-cache-provider" を直接指定
+// しても現状は解決できるが、これは apps/sandbox の直接依存ではなく expo 経由の推移依存
+// （pnpm-lock.yaml にのみ存在）のため、意図して "expo/..." のサブパス経由で参照する。
 //
 // 詳細は docs/maestro.md を参照。
 export default ({ config }: ConfigContext): ExpoConfig => {

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -9,11 +9,19 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 //   fallback としても効くため clearState 後も再接続する）
 // - skipOnboarding / showMenuAtLaunch / toolsButton: オンボーディング・起動時メニュー・
 //   フローティングツールボタンが assert を阻害しないよう無効化する
+//
+// buildCacheProvider: expo run:android/ios のネイティブフィンガープリントが前回と一致する
+// 場合、Gradle ビルドをスキップしローカルキャッシュ（apps/sandbox/.expo/build-cache）済みの
+// バイナリを再利用させる。CI（e2e.yml）側で actions/cache によりこのディレクトリを永続化する。
+// 値は必ずオブジェクト形式で指定すること（生文字列は @expo/cli が
+// "Invalid build cache provider" として拒否する）。
+//
 // 詳細は docs/maestro.md を参照。
 export default ({ config }: ConfigContext): ExpoConfig => {
   const plugins = [...(config.plugins ?? [])];
+  const isE2EBuild = process.env.E2E_BUILD === "true";
 
-  if (process.env.E2E_BUILD === "true") {
+  if (isE2EBuild) {
     const devClientPlugin: [string, Record<string, unknown>] = [
       "expo-dev-client",
       {
@@ -31,6 +39,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     name: config.name ?? "sandbox",
     slug: config.slug ?? "sandbox",
     plugins,
+    ...(isE2EBuild
+      ? { buildCacheProvider: { plugin: "expo/local-build-cache-provider" } }
+      : {}),
     extra: {
       ...config.extra,
       // E2E ビルドでアプリの表示言語を固定するための既定値（src/i18n/locale.ts が参照）。

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -39,9 +39,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     name: config.name ?? "sandbox",
     slug: config.slug ?? "sandbox",
     plugins,
-    ...(isE2EBuild
-      ? { buildCacheProvider: { plugin: "expo/local-build-cache-provider" } }
-      : {}),
+    ...(isE2EBuild ? { buildCacheProvider: { plugin: "expo/local-build-cache-provider" } } : {}),
     extra: {
       ...config.extra,
       // E2E ビルドでアプリの表示言語を固定するための既定値（src/i18n/locale.ts が参照）。

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -27,12 +27,21 @@ Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテ
   は release variant でビルドされ、`lintVitalRelease`（lint）が CI ランナーのメモリを使い切って
   `OutOfMemoryError` で落ちる。lint は E2E ビルドに不要（品質チェックは oxlint / expo lint で別途実施）なため、
   `e2e` プロファイルの `android.gradleCommand` を `:app:assembleRelease -x lintVitalRelease` にして除外している。
+- **ネイティブ部分に変更が無ければ Gradle ビルドをスキップする**。`apps/sandbox/app.config.ts` が
+  `E2E_BUILD=true` のときだけ `buildCacheProvider` に組み込みのローカル provider
+  （`expo/local-build-cache-provider`）を設定する。`expo run:android` はネイティブのフィンガープリント
+  （`@expo/fingerprint`。依存関係・ネイティブコード・config plugin・app.json/app.config の設定が対象。
+  JS/TSX のアプリケーションソースは対象外）が前回と一致すればキャッシュ済みバイナリの install・Metro 起動まで
+  内部で自動的に行い、フルビルドをスキップする。CI では `apps/sandbox/.expo/build-cache`（既定のキャッシュ
+  保存先）を `actions/cache` で永続化する。多くの PR は JS のみの変更でネイティブ部分は変わらないため、
+  この場合は毎回のフルビルドを避けられる。値は必ずオブジェクト形式 `{ plugin: "..." }` で指定すること
+  （生文字列は `@expo/cli` に `Invalid build cache provider` として拒否される）。
 
 ## 構成ファイル
 
 | ファイル | 役割 |
 | --- | --- |
-| `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
+| `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）と `buildCacheProvider`（ネイティブビルドキャッシュ）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
 | `apps/sandbox/eas.json` の `e2e` プロファイル | 将来の非 Dev Client 用 E2E ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
 | `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
 | `.github/workflows/e2e.yml` | PR ごとに「emulator 起動 → `E2E_BUILD=true expo run:android`（build→install→Metro→接続）→ maestro test」を1ジョブで実行 |
@@ -136,6 +145,14 @@ maestro test apps/sandbox/.maestro/
 - 失敗時も `maestro-report.xml`（JUnit）・`--debug-output` のスクショ/録画/ログ・`expo-run.log`・
   画面診断（スクショ/ロケール/前面 activity/UI テキスト）を artifact に保存する。
 - Maestro CLI は再現性のためバージョン固定（`MAESTRO_VERSION`）。更新は意図的に PR で上げる。
+- **ネイティブビルドキャッシュ**（`buildCacheProvider`）が使う `apps/sandbox/.expo/build-cache` を
+  `actions/cache` で永続化する（`Restore native build cache` ステップ）。key は `github.run_id` で
+  常にユニークにし `restore-keys` で直近のキャッシュを復元する成長型キャッシュとしている。固定キーだと
+  `actions/cache` の「完全一致時は保存しない」仕様により、ネイティブ変更後も二度と更新されなくなるため。
+  ヒット/ミスの判定は `expo-run.log` を要約する `Summarize native build cache result` ステップが
+  Job Summary に表示する。異なるフィンガープリントのキャッシュエントリは自動削除されず
+  `.expo/build-cache` は増え続けるが、GitHub 側の自動退役に任せている。キャッシュミス時は通常の
+  フルビルドに安全にフォールバックする。
 
 ## iOS を対象に追加する場合
 

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -36,13 +36,9 @@ Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテ
   保存先）を `actions/cache` で永続化する。多くの PR は JS のみの変更でネイティブ部分は変わらないため、
   この場合は毎回のフルビルドを避けられる。値は必ずオブジェクト形式 `{ plugin: "..." }` で指定すること
   （生文字列は `@expo/cli` に `Invalid build cache provider` として拒否される）。
-  - `apps/sandbox/.fingerprintignore` で `@react-native-masked-view/masked-view` の
-    `android/src/main/AndroidManifest.xml` を除外している。このファイルは Gradle ビルド中に
-    （AGP8 互換のための package 属性除去とみられる書き換えで）内容が変わり、ビルド前
-    （`resolveBuildCache`）とビルド後（`uploadBuildCache`）でフィンガープリントが一致せず
-    キャッシュが常に MISS になる原因だったため、実際に CI 上でビルド前後の fingerprint の
-    ソース単位ハッシュを比較して特定した。今後同様に「ビルドで node_modules 内のファイルが
-    書き換わる」パッケージが見つかった場合はこのファイルに追記する。
+  - `apps/sandbox/.fingerprintignore` でビルド中に内容が変わり誤検出を招く既知のファイルを
+    除外している。原因・調査内容はファイル内のコメントを参照。今後同様のパッケージが
+    見つかった場合はこのファイルに追記する。
 
 ## 構成ファイル
 

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -36,12 +36,20 @@ Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテ
   保存先）を `actions/cache` で永続化する。多くの PR は JS のみの変更でネイティブ部分は変わらないため、
   この場合は毎回のフルビルドを避けられる。値は必ずオブジェクト形式 `{ plugin: "..." }` で指定すること
   （生文字列は `@expo/cli` に `Invalid build cache provider` として拒否される）。
+  - `apps/sandbox/.fingerprintignore` で `@react-native-masked-view/masked-view` の
+    `android/src/main/AndroidManifest.xml` を除外している。このファイルは Gradle ビルド中に
+    （AGP8 互換のための package 属性除去とみられる書き換えで）内容が変わり、ビルド前
+    （`resolveBuildCache`）とビルド後（`uploadBuildCache`）でフィンガープリントが一致せず
+    キャッシュが常に MISS になる原因だったため、実際に CI 上でビルド前後の fingerprint の
+    ソース単位ハッシュを比較して特定した。今後同様に「ビルドで node_modules 内のファイルが
+    書き換わる」パッケージが見つかった場合はこのファイルに追記する。
 
 ## 構成ファイル
 
 | ファイル | 役割 |
 | --- | --- |
 | `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）と `buildCacheProvider`（ネイティブビルドキャッシュ）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
+| `apps/sandbox/.fingerprintignore` | ネイティブビルドキャッシュのフィンガープリント計算から除外するパス。ビルドで内容が変わり無限に MISS を招く既知のファイル（`@react-native-masked-view/masked-view` の `AndroidManifest.xml` 等）を列挙 |
 | `apps/sandbox/eas.json` の `e2e` プロファイル | 将来の非 Dev Client 用 E2E ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
 | `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
 | `.github/workflows/e2e.yml` | PR ごとに「emulator 起動 → `E2E_BUILD=true expo run:android`（build→install→Metro→接続）→ maestro test」を1ジョブで実行 |


### PR DESCRIPTION
## 概要

E2E CI（`e2e-android`）で毎回ゼロから行っている `expo run:android` の Gradle フルビルドを、ネイティブ部分に変更がない場合はスキップし、キャッシュ済みバイナリを再利用できるようにする。

## 背景・動機

CI は Continuous Native Generation 方針（`android/`/`ios/` は git 管理外で毎回 `expo prebuild` により生成）のもと、`E2E_BUILD=true pnpm --dir apps/sandbox exec expo run:android` で毎回 Gradle フルビルドを行っており、これが E2E ジョブの主なボトルネックになっている。多くの PR は JS/TSX のみの変更で、ネイティブ部分（依存関係・ネイティブコード・config plugin・app.json/app.config の設定）は変わらないため、この場合はビルドをスキップして再利用できる余地がある。

なお、調査当初は「`eas build --local` が遅い」という前提だったが、実際には現行 `e2e.yml` は `eas build --local` を使っておらず、ボトルネックは `expo run:android` のローカル Gradle ビルドだった（`eas.json` の `e2e` プロファイルは将来の非 Dev Client 回帰テスト用で現行 CI では未使用）。この事実確認を踏まえ、既存の `expo run:android` ベースの構成はそのままに、Expo CLI 公式のビルドキャッシュ機構（[Build cache providers](https://docs.expo.dev/guides/cache-builds-remotely/)）を追加する方針とした。

## アプローチ

- `apps/sandbox/app.config.ts`: `E2E_BUILD=true` のときだけ `buildCacheProvider` に組み込みのローカル provider（`expo/local-build-cache-provider`、追加インストール不要）を設定。ネイティブのフィンガープリントが前回と一致すれば `expo run:android` が内部で自動的に Gradle ビルドをスキップし、キャッシュ済みバイナリの install・Metro 起動まで行う。呼び出し側（`expo run:android` そのもの）を変更する必要はない。
  - `node_modules` 内の実装を実際に読んで確認した結果、`buildCacheProvider` は生文字列ではなくオブジェクト形式（`{ plugin: "..." }`）で指定する必要があると判明（生文字列は `@expo/cli` に `Invalid build cache provider` として拒否される。README の記載と実装が食い違っていた。Copilot のレビュー指摘 [#discussion_r3518133616](https://github.com/yami-beta/expo-sandbox/pull/207#discussion_r3518267511) 参照）。
  - EAS アカウント・ネットワーク通信が不要なローカルファイルシステムベースの provider のため、既存の「EAS ビルドクレジットを使わない」方針と両立する。
  - `@expo/repack-app` は当初の改善案の1つだったが、本リポジトリの E2E は Dev Client 運用（JS は埋め込みでなく Metro 配信）のため、JS/アセットの差し替えを行う repack-app のユースケースには合致せず不採用とした。
- `.github/workflows/e2e.yml`:
  - `apps/sandbox/.expo/build-cache`（provider の既定キャッシュディレクトリ）を `actions/cache` で永続化する「Restore native build cache」ステップを追加。key は `github.run_id` で常にユニークにし `restore-keys` で直近のキャッシュを復元する成長型キャッシュとした（固定キーだと `actions/cache` の「完全一致時は保存しない」仕様により、ネイティブ変更後も二度と更新されなくなるため）。
  - `expo-run.log` を要約してキャッシュのヒット/ミスを Job Summary に表示する「Summarize native build cache result」ステップを追加。
- `apps/sandbox/.fingerprintignore`: 後述の根本原因対応。

### 却下した代替案

- 自前でフィンガープリントを計算し、キャッシュヒット時は `expo run:android` の代わりに `expo start` + `adb install` を手動で組む案も検討したが、Expo CLI 公式のビルドキャッシュ機構がこれと同等（かそれ以上）のことを内部で行ってくれるため不採用。呼び出し側の変更を最小限にできる。

## CI 検証で発見・修正した重大な問題

実際に本 PR で CI を複数回実行して検証したところ、**同一コミットを再実行してもキャッシュが常に MISS になる**（機能が全く効かない）不具合が判明した。原因調査のため一時的なデバッグステップを追加し、`expo run:android` のビルド前（`resolveBuildCache` 相当）とビルド後（`uploadBuildCache` 相当）でフィンガープリントのソース単位ハッシュを実際の CI 実行上で比較した結果、`node_modules/@react-native-masked-view/masked-view/android/src/main/AndroidManifest.xml` のみが差分として見つかった。

このファイルは Gradle ビルド中に書き換えられており（内容から見て AGP8 互換のための `package` 属性除去とみられる）、`@expo/fingerprint` のデフォルトのハッシュ対象に含まれてしまっていたため、ビルド前後で同一コミットでも異なるフィンガープリントが計算され、過去にアップロードされたキャッシュに絶対にヒットしない構造になっていた。ローカル環境では `node_modules` が既にパッチ済みの状態で固定されていたため再現できず、発見が遅れた。

`apps/sandbox/.fingerprintignore` で該当ファイルを明示的に除外することで解決した（`@expo/fingerprint` がこの用途のために標準サポートしている機構）。

## 実測結果（本 PR の CI ログで確認済み）

- 1回目（`.fingerprintignore` 追加前）: キャッシュミス → フルビルド（約12〜13分）→ `.expo/build-cache` へアップロード、を複数回のコミットにわたって確認。同一コミットの再実行でも常に MISS になることを確認（上記の不具合）。
- `.fingerprintignore` 追加後、1回目: 除外パターンの追加でフィンガープリントの計算方法自体が変わるため想定通り MISS（1回限りのコスト）。
- `.fingerprintignore` 追加後、同一コミットを再実行: **キャッシュヒットを確認**。`.expo/build-cache/android-<hash>-unknown.apk` からインストールされ、Gradle ビルドは一切発生せず、ジョブ全体が **3分45秒**で完了（フルビルド時の12〜13分から約70%短縮）。

## リスク・運用上の注意

- 異なるフィンガープリントのキャッシュエントリは自動削除されないため `.expo/build-cache` は増え続ける。まずは GitHub 側の自動退役に任せ、追加の削除ジョブは設けない。
- キャッシュミス（フィンガープリント不一致）時は通常のフルビルドに安全にフォールバックする。プロバイダの設定値そのものが不正な場合のみ `expo run:android` が起動前に失敗する（今回の設定値は実装を確認済み）。
- 今後同様に「ビルドで `node_modules` 内のファイルが書き換わる」パッケージが見つかった場合は `.fingerprintignore` に追記する運用とする。

## レビューポイント

- `actions/cache` の key 設計（run_id + restore-keys の成長型キャッシュ）の妥当性
- `.fingerprintignore` によるピンポイントな除外という対処方針の妥当性（vs. 他の根本対応）

## Test plan

- [x] 1回目の CI 実行: キャッシュミスでフルビルドされ、ビルド後にキャッシュへ保存されることを Job Summary / ログで確認
- [x] 同一コミットの再実行でキャッシュヒットし Gradle ビルドがスキップされることを確認（`.fingerprintignore` 追加後）
- [x] キャッシュヒット時の所要時間がフルビルド時より明確に短縮されていることを確認（12〜13分 → 3分45秒）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
