### PR TITLE
ci(e2e): main への push 時に Maestro E2E を実行する

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -31,8 +31,13 @@ jobs:
   # E2E_BUILD は設定しない。設定すると apps/sandbox/app.config.ts が expo-dev-client plugin と
   # buildCacheProvider（expo run:android 専用のネイティブビルドキャッシュ）を有効化してしまい、
   # release / 埋め込み JS のビルドに Dev Client が混入するため。
+  # dependabot が @dependabot merge 等で直接 main に push した場合、actor が dependabot[bot]
+  # になり secrets.EXPO_TOKEN が渡らず setup-eas が明示エラーで落ちる。main の E2E が
+  # 恒常的に失敗してノイズになるのを避けるため、このケースはジョブごと skip する
+  # （e2e.yml の dependabot 除外と同様の意図）。
   e2e-android:
     name: E2E (Android / main)
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -1,7 +1,7 @@
-name: e2e
+name: e2e-main
 
 on:
-  pull_request:
+  push:
     branches: [main]
     paths:
       - 'apps/sandbox/**'
@@ -9,36 +9,30 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'package.json'
-      - '.github/workflows/e2e.yml'
+      - '.github/workflows/e2e-main.yml'
       - '.github/actions/**'
+  workflow_dispatch:
 
 concurrency:
-  group: e2e-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: e2e-main
+  cancel-in-progress: false
 
 env:
-  # install.sh が cli- を付与するため数値のみを指定（再現性のためバージョン固定）
+  # install.sh が cli- を付与するため数値のみを指定（再現性のためバージョン固定。e2e.yml と同一値）
   MAESTRO_VERSION: '2.6.1'
   ANDROID_API_LEVEL: '34'
   AVD_NAME: e2e
 
 jobs:
-  # Development Build（Dev Client 入り）を expo run:android でビルド→install→Metro 起動→
-  # アプリ起動まで一括実行し、その上で Maestro E2E を実行する（ローカル開発と同一コマンド）。
-  # E2E_BUILD=true により app.config.ts が dev-client の config plugin を有効化し、
-  # defaultLaunchURL(http://localhost:8081) で launcher を経由せず Metro へ自動接続する。
-  # EAS / EXPO_TOKEN は不要。
-  # ネイティブフィンガープリントが前回と一致する場合は expo run:android 自体が
-  # Gradle ビルドをスキップしてキャッシュ済みバイナリを再利用する
-  # （apps/sandbox/app.config.ts の buildCacheProvider、下記 actions/cache で永続化）。
-  # ※ アプリ起動時の Metro バンドル生成（CPU スパイク）で低速 emulator の SystemUI/Launcher が ANR
-  #   しないよう、emulator は CI 向け軽量イメージ google_atd を使う（system process が軽く ANR しにくい）。
-  #   コマンドは素の expo run:android のままで、nice や pre-warm 等の小細工は使わない。
-  # Dev Client を含まない（e2e プロファイル / 埋め込み JS）E2E は e2e-main.yml（main への push）で行う。
-  # 将来 iOS を対象にする場合は e2e-ios ジョブ（macOS ランナー / simulator）を追加する。
+  # Dev Client を含まない release ビルド（eas.json の e2e プロファイル / 埋め込み JS）を
+  # eas build --local でビルドし、emulator に install した上で Maestro E2E を実行する。
+  # e2e.yml（PRごと、Dev Client + expo run:android + Metro 接続）とはビルド経路が根本的に
+  # 異なるため、共通化はせず独立したワークフローとする。
+  # E2E_BUILD は設定しない。設定すると apps/sandbox/app.config.ts が expo-dev-client plugin と
+  # buildCacheProvider（expo run:android 専用のネイティブビルドキャッシュ）を有効化してしまい、
+  # release / 埋め込み JS のビルドに Dev Client が混入するため。
   e2e-android:
-    name: E2E (Android)
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    name: E2E (Android / main)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,21 +41,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      # expo run:android のネイティブビルドキャッシュ（apps/sandbox/app.config.ts の
-      # buildCacheProvider）が使うディレクトリを永続化する。fingerprint が前回と一致すれば
-      # expo run:android が Gradle ビルドをスキップしてこの中のバイナリを再利用する。
-      # key は常にユニーク（run_id）にし restore-keys で直近のキャッシュを復元する
-      # 成長型キャッシュとする。固定キーだと actions/cache の「完全一致時は保存しない」仕様により
-      # ネイティブ変更後も更新されなくなるため。異なる fingerprint のエントリは自動削除されず
-      # ディレクトリは増え続けるが、GitHub 側の自動退役に任せる（docs/maestro.md 参照）。
-      - name: Restore native build cache
-        uses: actions/cache@v6
-        with:
-          path: apps/sandbox/.expo/build-cache
-          key: e2e-android-buildcache-${{ github.run_id }}
-          restore-keys: |
-            e2e-android-buildcache-
 
       - name: Setup JDK
         uses: actions/setup-java@v5
@@ -74,6 +53,11 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
+
+      - name: Setup EAS
+        uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install Maestro CLI
         run: |
@@ -111,7 +95,9 @@ jobs:
             --package "system-images;android-${ANDROID_API_LEVEL};google_atd;x86_64" \
             --device "pixel_6"
 
-      - name: Run Maestro E2E
+      # eas.json の e2e プロファイル（developmentClient: false / release / lintVitalRelease 除外）で
+      # ビルドする。E2E_DEFAULT_LOCALE のみ設定し E2E_BUILD は設定しない（上記コメント参照）。
+      - name: Build Android APK (eas build --local, e2e profile)
         env:
           # x86_64 のみビルドして emulator の arch と一致させる（ビルド時間短縮）
           ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
@@ -120,9 +106,15 @@ jobs:
           # getStoredLocalePreference() の（保存値が無いときの）フォールバックとして参照される。
           E2E_DEFAULT_LOCALE: ja
         run: |
+          eas build --local --profile e2e --platform android \
+            --non-interactive --output ./build-output/sandbox-e2e.apk
+        working-directory: apps/sandbox
+
+      - name: Start emulator and wait for boot
+        run: |
           # emulator をバックグラウンド起動（テスト端末ロケールは既定の en-US を使う）
-          # CI 用の軽量イメージ（google_atd）を使い、アプリ起動時の Metro バンドル生成（CPU スパイク）で
-          # SystemUI/Launcher が ANR するのを抑える。余裕のため RAM/コアも増やす。
+          # CI 用の軽量イメージ（google_atd）を使い、release ビルド初回起動時の CPU 負荷で
+          # SystemUI/Launcher が ANR するのを抑える（e2e.yml と同じ対策）。余裕のため RAM/コアも増やす。
           "$ANDROID_HOME/emulator/emulator" -avd "$AVD_NAME" \
             -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect \
             -memory 6144 -cores 4 &
@@ -144,41 +136,16 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global animator_duration_scale 0
 
-          # Development Build を expo run:android でビルド→install→Metro 起動→adb reverse→
-          # アプリ起動まで一括実行する（ローカル開発と同一コマンド）。Metro はテスト中ずっと
-          # 生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
-          E2E_BUILD=true pnpm --dir apps/sandbox exec expo run:android > "$RUNNER_TEMP/expo-run.log" 2>&1 &
-          EXPO_RUN_PID=$!
-          echo "EXPO_RUN_PID=$EXPO_RUN_PID" >> "$GITHUB_ENV"
+      # アプリの起動は行わない。apps/sandbox/.maestro/smoke.yaml の先頭が launchApp であり、
+      # maestro test 自体が起動を担う（e2e.yml では expo run:android が install の副作用として
+      # 自動起動するため待機ロジックがあるが、ここでは install 済みであれば launchApp が起動できる）。
+      - name: Install app
+        run: adb install -r apps/sandbox/build-output/sandbox-e2e.apk
 
-          # ビルド→install→アプリ起動（MainActivity）まで待つ。expo run が途中で死んだら失敗させる
-          timeout 1200 bash -c '
-            until adb shell dumpsys activity activities 2>/dev/null | tr -d "\r" | grep -q "com.yamibeta.sandbox/.MainActivity"; do
-              kill -0 '"$EXPO_RUN_PID"' 2>/dev/null || { echo "expo run:android が予期せず終了しました"; exit 1; }
-              sleep 5
-            done'
-          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）
-          timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
-
+      - name: Run Maestro E2E
+        run: |
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
-
-      # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
-      # grep パターンは node_modules/@expo/local-build-cache-provider・
-      # node_modules/@expo/cli の実際のログ文言に基づく。
-      - name: Summarize native build cache result
-        if: always()
-        run: |
-          LOG="$RUNNER_TEMP/expo-run.log"
-          if [ ! -f "$LOG" ]; then
-            echo "### Native build cache: expo-run.log が見つかりません" >> "$GITHUB_STEP_SUMMARY"
-          elif grep -qE 'Installing .*\.expo/build-cache/' "$LOG"; then
-            echo "### Native build cache: HIT（ネイティブビルドをスキップ）" >> "$GITHUB_STEP_SUMMARY"
-          elif grep -q 'Copying build to local cache' "$LOG"; then
-            echo "### Native build cache: MISS（フルビルド実行 → 今回の成果をキャッシュに追加）" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "### Native build cache: 判定不能（expo-run.log を確認）" >> "$GITHUB_STEP_SUMMARY"
-          fi
 
       # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
       # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）
@@ -199,25 +166,18 @@ jobs:
           echo "=== top activity ==="; cat "$RUNNER_TEMP/diag/activity.txt" 2>/dev/null || true
           echo "=== UI に表示中のテキスト（抜粋） ==="; grep -oE 'text="[^"]+"' "$RUNNER_TEMP/diag/ui.xml" 2>/dev/null | head -40 || true
 
-      # Metro を停止し、ポート転送を解除する（バックグラウンドプロセスの hang 防止）
-      - name: Stop Expo / Metro
-        if: always()
-        run: |
-          adb reverse --remove-all || true
-          kill "$EXPO_RUN_PID" 2>/dev/null || true
-          pkill -f "expo run:android" 2>/dev/null || true
-          pkill -f "expo start" 2>/dev/null || true
-
-      # 成功・失敗にかかわらずレポート・スクショ/録画/ログ・診断（画面状態）を保存する
+      # 成功・失敗にかかわらずレポート・スクショ/録画/ログ・診断（画面状態）・APK を保存する
       - name: Upload Maestro artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: maestro-results-${{ github.event.pull_request.number }}
+          name: maestro-results-${{ github.sha }}
           path: |
             maestro-report.xml
             maestro-debug
-            ${{ runner.temp }}/expo-run.log
+            apps/sandbox/build-output/sandbox-e2e.apk
             ${{ runner.temp }}/diag
           retention-days: 7
           if-no-files-found: warn
+          # 同一コミットへの re-run で同名アーティファクトが既に存在する場合の 409 Conflict を避ける
+          overwrite: true

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -14,11 +14,14 @@ appId: com.yamibeta.sandbox
 # Dev Client ビルド（e2e.yml / PR）は clearState 後、defaultLaunchURL 経由で Metro に再接続し
 # バンドルを再取得する際、「ホーム」が一瞬表示された直後に画面が空白になることがあり、
 # 過去にこれを避けるため待機対象を「ナビゲーションパターン」（リスト描画完了の証跡）に
-# 変更したことがある。表示確認としての分かりやすさを優先してこの順序に戻しているため、
-# Dev Client 側でこの空白挙動による flaky failure が再発した場合は待機対象の変更や
-# flow の分割を検討すること。
+# 変更したことがある。表示確認としての分かりやすさを優先してこの順序に戻すが、
+# 「ナビゲーションパターン」を既定（短め）のタイムアウトの assertVisible のままにすると、
+# リスト描画が遅いタイミングでは "ホーム" の表示後に空白を挟んで flaky failure になりうる
+# ため、こちらも extendedWaitUntil で長めに待ってから assert する。
 - extendedWaitUntil:
     visible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
     timeout: 120000
-- assertVisible: "ナビゲーションパターン" # GroupedList の先頭項目
+- extendedWaitUntil:
+    visible: "ナビゲーションパターン" # GroupedList の先頭項目
+    timeout: 120000
 - assertVisible: "コンポーネント"

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -15,9 +15,11 @@ appId: com.yamibeta.sandbox
 # バンドルを再取得する際、「ホーム」が一瞬表示された直後に画面が空白になることがあり、
 # 過去にこれを避けるため待機対象を「ナビゲーションパターン」（リスト描画完了の証跡）に
 # 変更したことがある。表示確認としての分かりやすさを優先してこの順序に戻すが、
-# 「ナビゲーションパターン」を既定（短め）のタイムアウトの assertVisible のままにすると、
-# リスト描画が遅いタイミングでは "ホーム" の表示後に空白を挟んで flaky failure になりうる
-# ため、こちらも extendedWaitUntil で長めに待ってから assert する。
+# assertVisible の既定の自動リトライは7秒（docs.maestro.dev/reference/commands-available/
+# assertvisible 参照）しかなく、このリストの遅延はそれをはるかに超える場合がある
+# （このタイムアウトが 40000 → 60000 → 120000 と段階的に伸ばされてきた過去の経緯を参照。
+# git log --follow -p -- apps/sandbox/.maestro/smoke.yaml）。そのため「ナビゲーションパターン」も
+# assertVisible の既定リトライに任せず extendedWaitUntil で同じ長さまで待ってから assert する。
 - extendedWaitUntil:
     visible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
     timeout: 120000

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -9,21 +9,19 @@ appId: com.yamibeta.sandbox
 ---
 - launchApp:
     clearState: true
-# ページの表示確認としてまず画面タイトル「ホーム」を待ってから assert する。
-# 埋め込み JS ビルド（e2e-main.yml / main）はこの順序で問題なく動く。
-# Dev Client ビルド（e2e.yml / PR）は clearState 後、defaultLaunchURL 経由で Metro に再接続し
-# バンドルを再取得する際、「ホーム」が一瞬表示された直後に画面が空白になることがあり、
-# 過去にこれを避けるため待機対象を「ナビゲーションパターン」（リスト描画完了の証跡）に
-# 変更したことがある。表示確認としての分かりやすさを優先してこの順序に戻すが、
-# assertVisible の既定の自動リトライは7秒（docs.maestro.dev/reference/commands-available/
-# assertvisible 参照）しかなく、このリストの遅延はそれをはるかに超える場合がある
-# （このタイムアウトが 40000 → 60000 → 120000 と段階的に伸ばされてきた過去の経緯を参照。
-# git log --follow -p -- apps/sandbox/.maestro/smoke.yaml）。そのため「ナビゲーションパターン」も
-# assertVisible の既定リトライに任せず extendedWaitUntil で同じ長さまで待ってから assert する。
-- extendedWaitUntil:
-    visible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
-    timeout: 120000
-- extendedWaitUntil:
-    visible: "ナビゲーションパターン" # GroupedList の先頭項目
-    timeout: 120000
+# ページの表示確認としてまず画面タイトル「ホーム」を assert し、続けて画面内の項目を確認する。
+# 過去（b0810b4）に、Dev Client ビルド（e2e.yml / PR）で clearState 後 defaultLaunchURL 経由で
+# Metro に再接続する際、「ホーム」が一瞬表示された直後に画面が空白になる現象が観測され、
+# assertVisible の既定リトライ（7秒。docs.maestro.dev/reference/commands-available/assertvisible
+# 参照）では足りず、待機対象を「ナビゲーションパターン」に変更した上でタイムアウトを
+# 40000 → 60000 → 120000 と段階的に伸ばす対応が取られていた
+# （git log --follow -p -- apps/sandbox/.maestro/smoke.yaml 参照）。
+# しかし現在のコードベースでこの空白挙動は再現しない（Dev Client ビルドで clearState ありの
+# 状態から assertVisible のみ・既定リトライで launchApp→3件の assert まで計8回連続成功、
+# 1回あたり約13秒）。そのため extendedWaitUntil による延長は行わず、素の assertVisible に
+# 戻している。将来 Dev Client 側でこの空白挙動由来の flaky failure が再発した場合は、
+# テストのタイムアウトを伸ばす前に、まず実装側（Metro 再接続・router hydration 等）の
+# 遅延の原因を調査すること。
+- assertVisible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
+- assertVisible: "ナビゲーションパターン" # GroupedList の先頭項目
 - assertVisible: "コンポーネント"

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -3,18 +3,22 @@
 # app.config の設定）を伴わないため、CI のネイティブビルドキャッシュ（docs/maestro.md 参照）が
 # ヒットし expo run:android の Gradle ビルドがスキップされる想定。
 # emulator ロケールは固定せず（既定 en-US）、E2E ビルドはアプリの言語既定値を ja に固定する
-# （E2E_DEFAULT_LOCALE=ja / .github/workflows/e2e.yml・src/i18n/locale.ts 参照）。
+# （E2E_DEFAULT_LOCALE=ja / .github/workflows/e2e.yml・e2e-main.yml・src/i18n/locale.ts 参照）。
 # 表示テキストは lingui の <Trans>（sourceLocale=ja）。
 appId: com.yamibeta.sandbox
 ---
 - launchApp:
     clearState: true
-# clearState 後は Metro からバンドルを再取得するため、「ホーム」が一瞬出た後に再ロードで
-# 空画面を挟むことがある。タイトルだけ待つと後続 assert が空画面で落ちるため、リストが
-# 描画完了した証跡となる項目を extendedWaitUntil で待ってから assert する。
-# （Dev Client は Metro 初回バンドル、非 Dev Client は埋め込み JS の初回起動が遅い）
+# ページの表示確認としてまず画面タイトル「ホーム」を待ってから assert する。
+# 埋め込み JS ビルド（e2e-main.yml / main）はこの順序で問題なく動く。
+# Dev Client ビルド（e2e.yml / PR）は clearState 後、defaultLaunchURL 経由で Metro に再接続し
+# バンドルを再取得する際、「ホーム」が一瞬表示された直後に画面が空白になることがあり、
+# 過去にこれを避けるため待機対象を「ナビゲーションパターン」（リスト描画完了の証跡）に
+# 変更したことがある。表示確認としての分かりやすさを優先してこの順序に戻しているため、
+# Dev Client 側でこの空白挙動による flaky failure が再発した場合は待機対象の変更や
+# flow の分割を検討すること。
 - extendedWaitUntil:
-    visible: "ナビゲーションパターン" # GroupedList の先頭項目（src/app/(tabs)/(home)/index.tsx）
+    visible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
     timeout: 120000
-- assertVisible: "ホーム" # Stack.Screen.Title / タブラベル
+- assertVisible: "ナビゲーションパターン" # GroupedList の先頭項目
 - assertVisible: "コンポーネント"

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -164,11 +164,11 @@ maestro test apps/sandbox/.maestro/
 ## CI（`.github/workflows/e2e-main.yml`）
 
 - トリガー: `main` への push（`apps/sandbox/**` などの paths フィルタは `e2e.yml` と同様）。
-  手動検証用に `workflow_dispatch` も併設している。`e2e.yml` にある dependabot 除外条件（PR の
-  submitter 判定）はここでは付けていない。dependabot が `@dependabot merge` 等で直接 main に
-  push した場合は actor が `dependabot[bot]` になり `secrets.EXPO_TOKEN` が渡らず
-  `.github/actions/setup-eas` が明示エラーで失敗する経路が残るが、`eas-build-main.yml` も同じ
-  制約を持っており今回新たに生じたものではない。
+  手動検証用に `workflow_dispatch` も併設している。dependabot が `@dependabot merge` 等で
+  直接 main に push した場合、actor が `dependabot[bot]` になり `secrets.EXPO_TOKEN` が渡らず
+  `.github/actions/setup-eas` が明示エラーで失敗し main の E2E が恒常的に失敗するノイズに
+  なりうるため、`e2e.yml` の dependabot 除外と同様に `if: github.actor != 'dependabot[bot]'`
+  でジョブごと skip している。
 - ビルドは `eas build --local --profile e2e --platform android`（本番相当の release ビルド・
   Dev Client 無し・埋め込み JS）で行う。`E2E_BUILD` は設定しない（`E2E_DEFAULT_LOCALE=ja` のみ設定）。
   設定すると `app.config.ts` が `expo-dev-client` plugin と `buildCacheProvider` を有効化してしまい

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -1,13 +1,14 @@
 # E2E テスト（Maestro）
 
 [Maestro](https://maestro.dev/) を使った UI 自動テスト（E2E）の構成と運用。`apps/sandbox` の起動〜画面表示を
-Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）とは別系統。
+Pull Request ごと（`e2e.yml`）と main ブランチへの push ごと（`e2e-main.yml`）に自動検証する。
+jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）とは別系統。
 
 ## 方針
 
-- **EAS のビルドクレジットは使わない**。PR は `expo run:android`（GitHub Actions の Linux ランナー上で
-  ローカル gradle ビルド）で完結し、EAS リモートビルドや `EXPO_TOKEN` に依存しない。将来の非 Dev Client 用
-  `e2e` プロファイルのみ `eas build --local` を使う。
+- **EAS のビルドクレジットは PR では使わない**。PR は `expo run:android`（GitHub Actions の Linux ランナー上で
+  ローカル gradle ビルド）で完結し、EAS リモートビルドや `EXPO_TOKEN` に依存しない。main ブランチ用の
+  非 Dev Client `e2e` プロファイルのみ `eas build --local` を使う（`EXPO_TOKEN` が必要）。
 - **PR は Development Build（Dev Client / Metro 接続）でテストする**。ローカル開発（`expo start` +
   `expo run:ios/android`）と前提を揃え、release ではなく debug ビルドにすることでビルド時間も短縮する。
   Dev Client（`developmentClient: true`）は本来起動時に Metro dev server を探す launcher 画面が出るが、
@@ -21,9 +22,9 @@ Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテ
     起動時のデベロッパーメニュー・フローティングツールボタンが assert を阻害しないよう無効化する。
 - **フローは Dev Client あり/なしの両対応**。`defaultLaunchURL` による自動接続のおかげで、Maestro フローは
   単一の `launchApp` で済み、Dev Client あり（自動接続）/ なし（埋め込み JS）の両方が同じフローで通る。
-  Dev Client を含まない E2E（`e2e` プロファイル / release / 埋め込み JS）は将来 main ブランチ or 定期実行で
-  行う想定で、その際も同じフローを再利用する。
-- **release ビルドの lint を除外**（将来の非 Dev Client 用 `e2e` プロファイル）。`developmentClient: false`
+  Dev Client を含まない E2E（`e2e` プロファイル / release / 埋め込み JS）は `.github/workflows/e2e-main.yml`
+  で main ブランチへの push 時に実行し、同じフローを再利用する。
+- **release ビルドの lint を除外**（非 Dev Client 用 `e2e` プロファイル）。`developmentClient: false`
   は release variant でビルドされ、`lintVitalRelease`（lint）が CI ランナーのメモリを使い切って
   `OutOfMemoryError` で落ちる。lint は E2E ビルドに不要（品質チェックは oxlint / expo lint で別途実施）なため、
   `e2e` プロファイルの `android.gradleCommand` を `:app:assembleRelease -x lintVitalRelease` にして除外している。
@@ -46,9 +47,10 @@ Pull Request ごとに自動検証する。jest-expo / Vitest のユニットテ
 | --- | --- |
 | `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）と `buildCacheProvider`（ネイティブビルドキャッシュ）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
 | `apps/sandbox/.fingerprintignore` | ネイティブビルドキャッシュのフィンガープリント計算から除外するパス。ビルドで内容が変わり無限に MISS を招く既知のファイル（`@react-native-masked-view/masked-view` の `AndroidManifest.xml` 等）を列挙 |
-| `apps/sandbox/eas.json` の `e2e` プロファイル | 将来の非 Dev Client 用 E2E ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
+| `apps/sandbox/eas.json` の `e2e` プロファイル | 非 Dev Client 用 E2E ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
 | `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
 | `.github/workflows/e2e.yml` | PR ごとに「emulator 起動 → `E2E_BUILD=true expo run:android`（build→install→Metro→接続）→ maestro test」を1ジョブで実行 |
+| `.github/workflows/e2e-main.yml` | main への push ごとに「`eas build --local --profile e2e`（release / 埋め込み JS）→ emulator 起動 → APK install → maestro test」を1ジョブで実行 |
 
 ## フローの書き方
 
@@ -109,15 +111,16 @@ E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec expo run:andro
 maestro test apps/sandbox/.maestro/
 ```
 
-### 非 Dev Client 経路（将来 main 互換の回帰確認）
+### 非 Dev Client 経路（main 互換の回帰確認）
 
-EAS CLI（`npm i -g eas-cli`）と EAS ログイン（`eas login`）が必要。
+EAS CLI（`npm i -g eas-cli`）と EAS ログイン（`eas login`）が必要。`.github/workflows/e2e-main.yml`
+が CI で実行しているのと同じ経路。
 
 ```bash
 # 1. e2e プロファイルで APK をローカルビルド（Dev Client 無し・Metro 不要）
 #    非 Dev Client でも E2E_DEFAULT_LOCALE=ja をビルド時に設定すると app.config.ts 経由で
 #    extra.e2eDefaultLocale に埋め込まれる（expo-constants のビルドタスクが毎ビルド再評価するため
-#    Dev Client 経路と同じ仕組みで確実に反映される。※ この経路は現状 CI 未使用（将来 main 互換の回帰用））
+#    Dev Client 経路と同じ仕組みで確実に反映される）。
 E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec eas build --local --profile e2e --platform android \
   --non-interactive --output ./build-output/sandbox-e2e.apk
 
@@ -157,6 +160,31 @@ maestro test apps/sandbox/.maestro/
   Job Summary に表示する。異なるフィンガープリントのキャッシュエントリは自動削除されず
   `.expo/build-cache` は増え続けるが、GitHub 側の自動退役に任せている。キャッシュミス時は通常の
   フルビルドに安全にフォールバックする。
+
+## CI（`.github/workflows/e2e-main.yml`）
+
+- トリガー: `main` への push（`apps/sandbox/**` などの paths フィルタは `e2e.yml` と同様）。
+  手動検証用に `workflow_dispatch` も併設している。`e2e.yml` にある dependabot 除外条件（PR の
+  submitter 判定）はここでは付けていない。dependabot が `@dependabot merge` 等で直接 main に
+  push した場合は actor が `dependabot[bot]` になり `secrets.EXPO_TOKEN` が渡らず
+  `.github/actions/setup-eas` が明示エラーで失敗する経路が残るが、`eas-build-main.yml` も同じ
+  制約を持っており今回新たに生じたものではない。
+- ビルドは `eas build --local --profile e2e --platform android`（本番相当の release ビルド・
+  Dev Client 無し・埋め込み JS）で行う。`E2E_BUILD` は設定しない（`E2E_DEFAULT_LOCALE=ja` のみ設定）。
+  設定すると `app.config.ts` が `expo-dev-client` plugin と `buildCacheProvider` を有効化してしまい
+  Dev Client が混入するため。EAS の認証には `.github/actions/setup-eas`（`secrets.EXPO_TOKEN`）を使う。
+- Metro は使わないため、`expo run:android` のような build→install→起動の自動化は無い。ビルドした APK を
+  `adb install` するだけで、アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` の `launchApp` に
+  任せる（maestro test 実行前に明示的に起動する必要は無い）。
+- `e2e.yml` が使うネイティブビルドキャッシュ（`buildCacheProvider`）は使わない（上記の通り
+  `E2E_BUILD` を設定しないため）。そのため毎回フルの release ビルド相当になる。
+- `concurrency.group` は PR 番号が存在しないため固定文字列 `e2e-main` を使用し、
+  `cancel-in-progress: false` として実行中の検証を中断しない（GitHub Actions の concurrency 仕様上、
+  保留は最新 1 件のみ残るためキューが際限なく積み上がることはない）。
+- artifact 名は `maestro-results-${{ github.sha }}`（push イベントには PR 番号が無いため）。
+  失敗解析用にビルド済み APK も artifact に含める。
+- その他（emulator 起動・ANR 対策の `google_atd` イメージ・アニメーション無効化・
+  診断情報採取など）は `e2e.yml` と同じロジックを再利用している。
 
 ## iOS を対象に追加する場合
 


### PR DESCRIPTION
## 概要

main ブランチへの push（または手動 `workflow_dispatch`）をトリガーに、Dev Client を含まない本番ビルド形状（release / 埋め込み JS）で Maestro E2E を実行する新規ワークフロー `e2e-main.yml` を追加する。あわせて、既存の Maestro フロー（`smoke.yaml`）を実機検証に基づき見直した。

## 背景・動機

既存の `e2e.yml` は PR ごとに Dev Client（`expo run:android` + Metro 接続）で E2E を検証するのみで、main ブランチに対する E2E は未実装だった。`docs/maestro.md` には「Dev Client を含まない `e2e` プロファイル（release / 埋め込み JS）での E2E は将来 main ブランチ or 定期実行で行う」という設計方針が既に明記されており、`apps/sandbox/eas.json` にもそのための `e2e` プロファイルが用意済みだったため、今回これを実装した。

## アプローチ

### e2e-main.yml の追加

- 新規ワークフロー `.github/workflows/e2e-main.yml` を追加。トリガーは main への push のみ（手動検証用に `workflow_dispatch` も併設）。プラットフォームは既存 `e2e.yml` と同じく Android のみ（iOS は将来対応）。
- ビルドは `eas.json` の `e2e` プロファイルで `eas build --local --profile e2e` を実行。`E2E_BUILD` は意図的に設定しない（設定すると `app.config.ts` が `expo-dev-client` plugin と `buildCacheProvider` を有効化してしまい Dev Client が混入するため）。`E2E_DEFAULT_LOCALE=ja` のみ設定してロケールを固定する。
- Metro を使わないため `expo run:android` のような build→install→起動の自動化はなく、ビルド済み APK を `adb install` するのみ。アプリの起動は `apps/sandbox/.maestro/smoke.yaml` の `launchApp` に任せる。
- `concurrency.group` は PR 番号が使えないため固定文字列 `e2e-main` を使用し `cancel-in-progress: false` とする。artifact 名も `github.sha` を使用。
- dependabot が `@dependabot merge` 等で直接 main に push した場合 `secrets.EXPO_TOKEN` が渡らず `setup-eas` が明示エラーで落ちるため、`e2e.yml` と同様に `if: github.actor != 'dependabot[bot]'` でジョブごと skip する。
- **却下した代替案**: 既存 `e2e.yml` をそのまま push トリガーにも対応させる案は、`concurrency.group` / artifact 名が PR 番号に依存しており修正が必要な上、Dev Client ビルドでは本番ビルド形状の検証にならないため採用しなかった。
- **却下した代替案**: `e2e.yml` との共通ステップ（Android SDK/emulator セットアップ、診断採取等）を composite action へ抽出する案は、ビルド方式が Dev Client と release で根本的に異なり共通化すると条件分岐が増えて複雑になるため見送り、重複を許容する独立したワークフローとした。重複が問題になった時点で抽出を検討する。

### smoke.yaml の見直し

- 当初、ページ表示確認として `"ホーム"` を先に assert したいというフィードバックを受けたが、git 履歴を調査したところ、PR の E2E を Dev Client 化した際（`b0810b4`）に「clearState 後、Metro 再接続時に "ホーム" が一瞬表示された直後に画面が空白になる」flakiness を避けるため、あえて待機対象を `"ナビゲーションパターン"` に変更した経緯があった。
- 一度は `"ホーム"` を先に戻しつつ `extendedWaitUntil`（120秒）で両方の要素を待つ形にしたが、その後「そもそも今も待機が必要なのか実測すべき」「120秒も待つ必要があるなら実装側の問題では」という指摘を受け、Dev Client ビルド（e2e.yml / PR と同条件）で実機検証した。
- 検証の結果、`extendedWaitUntil` を使わず Maestro 既定の `assertVisible`（自動リトライ最大7秒。docs.maestro.dev で確認）のみで、`clearState` ありのフレッシュな状態から launchApp→3件の assert までをローカルで計11回連続成功（1回あたり5〜13秒）。過去に観測された空白挙動は現在のコードベースでは再現しないと判断し、`extendedWaitUntil` を撤去して素の `assertVisible` に戻した。実際の GitHub Actions CI（Dev Client 条件）でも 3分38秒で pass することを確認済み。

## レビューポイント

- `code-reviewer` によるレビューで blocker/major の指摘はなし。minor/nit（陳腐化したコメントの修正、artifact re-run 時の 409 Conflict 対策として `overwrite: true` を追加等）は反映済み。
- GitHub Copilot の自動レビューで2件のコメントを受け、いずれも反映済み: (1) `smoke.yaml` の待機の非対称性（後に実機検証の末 `extendedWaitUntil` 自体を撤去する形で解消）、(2) `e2e-main.yml` の dependabot 除外ガードの追加。
- `e2e-main.yml` は PR 上の CI では実行されない（トリガーが main への push / 手動 `workflow_dispatch` のみのため）。マージ前に一度 `workflow_dispatch` での手動実行を確認することを推奨する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)