### PR TITLE
ci(e2e): PR の Android E2E を fingerprint キャッシュ化し初回プッシュを高速化

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -226,7 +226,9 @@ jobs:
         with:
           token: ${{ secrets.EXPO_TOKEN }}
 
-      # e2e.yml と同一のコマンド・profile・env で fingerprint を計算する（ハッシュ一致が前提）
+      # e2e.yml と同一のコマンド・env で fingerprint を計算する（ハッシュ一致が初回ヒットの前提）。
+      # @expo/fingerprint（pnpm-lock.yaml 固定）を API 直呼びで使い、EAS 認証・ネットワーク不要かつ
+      # ランをまたいで決定的にする。詳細は e2e.yml の同ステップのコメント参照。
       - name: Compute native fingerprint
         id: fp
         working-directory: apps/sandbox
@@ -234,8 +236,8 @@ jobs:
           E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
-          HASH="$(eas fingerprint:generate --platform android --build-profile development --json --non-interactive | jq -r '.hash')"
-          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+          HASH="$(node -e "require('@expo/fingerprint').createProjectHashAsync(process.cwd(), { platforms: ['android'] }).then((h) => process.stdout.write(h)).catch((e) => { console.error(e); process.exit(1); })")"
+          if [ -z "$HASH" ]; then
             echo "::error::native fingerprint の取得に失敗しました" >&2
             exit 1
           fi

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -26,11 +26,10 @@ env:
 jobs:
   # Dev Client を含まない release ビルド（eas.json の e2e プロファイル / 埋め込み JS）を
   # eas build --local でビルドし、emulator に install した上で Maestro E2E を実行する。
-  # e2e.yml（PRごと、Dev Client + expo run:android + Metro 接続）とはビルド経路が根本的に
-  # 異なるため、共通化はせず独立したワークフローとする。
-  # E2E_BUILD は設定しない。設定すると apps/sandbox/app.config.ts が expo-dev-client plugin と
-  # buildCacheProvider（expo run:android 専用のネイティブビルドキャッシュ）を有効化してしまい、
-  # release / 埋め込み JS のビルドに Dev Client が混入するため。
+  # e2e.yml（PRごと、Dev Client + Metro 接続）とはビルド経路（profile / debug vs release）が
+  # 根本的に異なるため、ジョブは分ける。
+  # E2E_BUILD は設定しない。設定すると apps/sandbox/app.config.ts が expo-dev-client plugin を
+  # 有効化し、release / 埋め込み JS のビルドに Dev Client が混入するため。
   # dependabot が @dependabot merge 等で直接 main に push した場合、actor が dependabot[bot]
   # になり secrets.EXPO_TOKEN が渡らず setup-eas が明示エラーで落ちる。main の E2E が
   # 恒常的に失敗してノイズになるのを避けるため、このケースはジョブごと skip する
@@ -142,8 +141,8 @@ jobs:
           adb shell settings put global animator_duration_scale 0
 
       # アプリの起動は行わない。apps/sandbox/.maestro/smoke.yaml の先頭が launchApp であり、
-      # maestro test 自体が起動を担う（e2e.yml では expo run:android が install の副作用として
-      # 自動起動するため待機ロジックがあるが、ここでは install 済みであれば launchApp が起動できる）。
+      # maestro test 自体が起動を担う（release / 埋め込み JS のため Metro も不要。install 済みで
+      # あれば launchApp が起動できる）。
       - name: Install app
         run: adb install -r apps/sandbox/build-output/sandbox-e2e.apk
 
@@ -186,3 +185,96 @@ jobs:
           if-no-files-found: warn
           # 同一コミットへの re-run で同名アーティファクトが既に存在する場合の 409 Conflict を避ける
           overwrite: true
+
+  # PR の e2e.yml が使う dev-client debug APK のビルドキャッシュを main で温める。
+  # GitHub Actions のキャッシュはブランチスコープで、新規 PR ブランチが復元できるのは
+  # default ブランチ（main）が書き込んだキャッシュのみ。このジョブが main への push ごとに
+  # e2e.yml と同一の fingerprint / 同一 profile（development）で APK を eas build --local し
+  # actions/cache（同一キー e2e-android-devclient-apk-<hash>）へ保存することで、ネイティブ変更の
+  # 無い（JS のみの）PR が初回プッシュからヒットしてビルドを丸ごと省略できるようにする。
+  # 上の release e2e ジョブとは目的（release 検証 vs dev-client キャッシュ温め）が異なるため
+  # 独立したジョブとし、emulator / Metro / maestro は使わない（build のみ）。
+  warm-devclient-cache:
+    name: Warm dev-client APK cache
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # build のみ（emulator/maestro なし）だが、キャッシュミス時の初回フルビルドに余裕を持たせる
+    timeout-minutes: 60
+    env:
+      APK_PATH: apps/sandbox/build-output/sandbox-e2e-devclient.apk
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node
+
+      - name: Setup EAS
+        uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # e2e.yml と同一のコマンド・profile・env で fingerprint を計算する（ハッシュ一致が前提）
+      - name: Compute native fingerprint
+        id: fp
+        working-directory: apps/sandbox
+        env:
+          E2E_BUILD: 'true'
+          E2E_DEFAULT_LOCALE: ja
+        run: |
+          HASH="$(eas fingerprint:generate --platform android --build-profile development --json --non-interactive | jq -r '.hash')"
+          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+            echo "::error::native fingerprint の取得に失敗しました" >&2
+            exit 1
+          fi
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "native fingerprint: $HASH"
+
+      # e2e.yml と同一キー（arch も一致させる）。既にこの fingerprint がキャッシュ済みなら HIT し
+      # build は走らない。
+      - name: Cache dev-client APK
+        id: cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.APK_PATH }}
+          key: e2e-android-devclient-apk-x86_64-${{ steps.fp.outputs.hash }}
+
+      # キャッシュミス時のみビルドし、post ステップで actions/cache が default ブランチスコープへ保存する。
+      # x86_64 のみビルドして PR 側 emulator（x86_64）と arch を一致させる。
+      - name: Build dev-client APK (eas build --local)
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: apps/sandbox
+        env:
+          ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
+          E2E_BUILD: 'true'
+          E2E_DEFAULT_LOCALE: ja
+        run: |
+          eas build --local --profile development --platform android \
+            --non-interactive --output ./build-output/sandbox-e2e-devclient.apk
+
+      - name: Summarize APK cache result
+        if: always()
+        run: |
+          if [ -z "${{ steps.fp.outputs.hash }}" ]; then
+            echo "### dev-client APK cache: 判定不能（fingerprint の取得に失敗）" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
+            echo "### dev-client APK cache: HIT（最新 fingerprint がキャッシュ済み・温め不要）" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "fingerprint: \`${{ steps.fp.outputs.hash }}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### dev-client APK cache: MISS（eas build --local を実行 → キャッシュに保存）" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "fingerprint: \`${{ steps.fp.outputs.hash }}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -227,7 +227,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       # e2e.yml と同一のコマンド・env で fingerprint を計算する（ハッシュ一致が初回ヒットの前提）。
-      # @expo/fingerprint（pnpm-lock.yaml 固定）を API 直呼びで使い、EAS 認証・ネットワーク不要かつ
+      # @expo/fingerprint（pnpm-lock.yaml 固定）の CLI を使い、EAS 認証・ネットワーク不要かつ
       # ランをまたいで決定的にする。詳細は e2e.yml の同ステップのコメント参照。
       - name: Compute native fingerprint
         id: fp
@@ -236,8 +236,8 @@ jobs:
           E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
-          HASH="$(node -e "require('@expo/fingerprint').createProjectHashAsync(process.cwd(), { platforms: ['android'] }).then((h) => process.stdout.write(h)).catch((e) => { console.error(e); process.exit(1); })")"
-          if [ -z "$HASH" ]; then
+          HASH="$(pnpm exec fingerprint fingerprint:generate --platform android | jq -r '.hash')"
+          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
             echo "::error::native fingerprint の取得に失敗しました" >&2
             exit 1
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,8 @@ env:
   APK_PATH: apps/sandbox/build-output/sandbox-e2e-devclient.apk
 
 jobs:
-  # Development Build（Dev Client 入り）の debug APK を eas build --local でビルドし、
-  # emulator に install → Metro（expo start）を起動 → Maestro E2E を実行する。
+  # Development Build（Dev Client 入り）の debug APK を eas build --local でビルドし、その APK を
+  # expo run:android --binary で emulator に install → Metro 起動 → dev-client 起動 → Maestro E2E を実行する。
   # ビルド成果物(APK)は @expo/fingerprint のハッシュをキーに actions/cache で永続化し、
   # ネイティブ fingerprint が一致する限り eas build --local を丸ごとスキップする。
   # main への push では e2e-main.yml の warm ジョブが同じ fingerprint / 同じ profile で
@@ -174,8 +174,8 @@ jobs:
         env:
           # E2E ビルドはアプリの言語既定値を ja に固定する（emulator ロケールは既定 en-US のまま）。
           # dev-client では Constants.expoConfig は Metro が配信する manifest 由来のため、
-          # expo start にも E2E_BUILD / E2E_DEFAULT_LOCALE を渡して app.config を同条件で評価させる
-          # （i18n/locale.ts の getStoredLocalePreference() のフォールバックが ja になる）。
+          # expo run:android が起動する Metro にも E2E_BUILD / E2E_DEFAULT_LOCALE を渡して app.config を
+          # 同条件で評価させる（i18n/locale.ts の getStoredLocalePreference() のフォールバックが ja になる）。
           E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
@@ -203,26 +203,24 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global animator_duration_scale 0
 
-          # ビルド済み（キャッシュ or eas build --local）の dev-client debug APK を install する
-          adb install -r "$APK_PATH"
+          # ビルド済み（キャッシュ or eas build --local）の dev-client debug APK を expo run:android に
+          # --binary で渡し、install → Metro 起動 → adb reverse → dev-client 起動（defaultLaunchURL で
+          # Metro へ接続）まで一括で行う。--binary で Gradle ビルドはスキップされる（ビルドは上の
+          # eas build --local 済み）。素の adb install + expo start では dev-client が Metro に接続せず
+          # 黒画面になるため、接続確立を含む expo run:android の launch ロジックを再利用する。
+          # Metro はテスト中ずっと生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
+          pnpm --dir apps/sandbox exec expo run:android --binary "$APK_PATH" > "$RUNNER_TEMP/expo-run.log" 2>&1 &
+          EXPO_RUN_PID=$!
+          echo "EXPO_RUN_PID=$EXPO_RUN_PID" >> "$GITHUB_ENV"
 
-          # Metro を background 起動する。Dev Client は defaultLaunchURL(http://localhost:8081) で
-          # 起動時に Metro へ自動接続するため、初回の明示 launch は不要（maestro の launchApp が担う）。
-          # Metro はテスト中ずっと生かす必要があるため PID は cleanup 用に記録する。
-          pnpm --dir apps/sandbox exec expo start > "$RUNNER_TEMP/expo-start.log" 2>&1 &
-          EXPO_START_PID=$!
-          echo "EXPO_START_PID=$EXPO_START_PID" >> "$GITHUB_ENV"
-
-          # device → host の Metro へポート転送（Dev Client が localhost:8081 に到達できるようにする）
-          adb reverse tcp:8081 tcp:8081
-
-          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）。
-          # expo start が途中で死んだら 120 秒待たず即失敗させる（診断の高速化）。
-          timeout 120 bash -c '
-            until curl -fsS http://localhost:8081/status 2>/dev/null | grep -q "packager-status:running"; do
-              kill -0 '"$EXPO_START_PID"' 2>/dev/null || { echo "expo start が予期せず終了しました"; exit 1; }
-              sleep 2
+          # install → dev-client 起動（MainActivity）まで待つ。expo run が途中で死んだら失敗させる
+          timeout 1200 bash -c '
+            until adb shell dumpsys activity activities 2>/dev/null | tr -d "\r" | grep -q "com.yamibeta.sandbox/.MainActivity"; do
+              kill -0 '"$EXPO_RUN_PID"' 2>/dev/null || { echo "expo run:android が予期せず終了しました"; exit 1; }
+              sleep 5
             done'
+          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）
+          timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
 
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
@@ -251,7 +249,8 @@ jobs:
         if: always()
         run: |
           adb reverse --remove-all || true
-          kill "$EXPO_START_PID" 2>/dev/null || true
+          kill "$EXPO_RUN_PID" 2>/dev/null || true
+          pkill -f "expo run:android" 2>/dev/null || true
           pkill -f "expo start" 2>/dev/null || true
 
       # 成功・失敗にかかわらずレポート・スクショ/録画/ログ・診断（画面状態）を保存する
@@ -263,7 +262,7 @@ jobs:
           path: |
             maestro-report.xml
             maestro-debug
-            ${{ runner.temp }}/expo-start.log
+            ${{ runner.temp }}/expo-run.log
             ${{ runner.temp }}/diag
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -209,7 +209,9 @@ jobs:
           # eas build --local 済み）。素の adb install + expo start では dev-client が Metro に接続せず
           # 黒画面になるため、接続確立を含む expo run:android の launch ロジックを再利用する。
           # Metro はテスト中ずっと生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
-          pnpm --dir apps/sandbox exec expo run:android --binary "$APK_PATH" > "$RUNNER_TEMP/expo-run.log" 2>&1 &
+          # --binary は絶対パスで渡す（pnpm --dir で cwd が apps/sandbox になり、リポジトリルート相対の
+          # $APK_PATH がそのままでは解決できないため $GITHUB_WORKSPACE を前置する）。
+          pnpm --dir apps/sandbox exec expo run:android --binary "$GITHUB_WORKSPACE/$APK_PATH" > "$RUNNER_TEMP/expo-run.log" 2>&1 &
           EXPO_RUN_PID=$!
           echo "EXPO_RUN_PID=$EXPO_RUN_PID" >> "$GITHUB_ENV"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,10 +72,14 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       # ネイティブフィンガープリント（@expo/fingerprint）を APK キャッシュのキーにする。
-      # E2E_BUILD / E2E_DEFAULT_LOCALE は app.config.ts が読む env。ビルドと同じ値を渡し、
-      # 同じ build profile（development）で計算することで、PR と e2e-main.yml の warm ジョブで
-      # ハッシュが一致する（fingerprint は JS を含まずネイティブ依存・config のみを対象とするため、
-      # JS のみの変更ではハッシュ不変 → 既存 APK を再利用でき、更新 JS は Metro が配信する）。
+      # eas-cli 経由（eas fingerprint:generate）ではなく @expo/fingerprint の API を直接使う:
+      # pnpm-lock.yaml でバージョン固定されるためランをまたいで決定的（eas-version: latest だと
+      # 実行時期でアルゴリズムがドリフトしキャッシュが常時 MISS になりうる）で、EAS 認証・ネットワークも
+      # 不要。E2E_BUILD / E2E_DEFAULT_LOCALE は app.config.ts の評価に反映され（ExpoConfigLoader が
+      # process.env を継承）、.fingerprintignore と eas.json も自動でハッシュ対象に含まれる。
+      # fingerprint は JS を含まずネイティブ依存・config のみが対象のため、JS のみの変更ではハッシュ
+      # 不変 → 既存 APK を再利用でき、更新 JS は Metro が配信する。PR と e2e-main.yml の warm ジョブは
+      # 同一コマンド・同一 env で計算するためハッシュが一致する。
       - name: Compute native fingerprint
         id: fp
         working-directory: apps/sandbox
@@ -83,8 +87,8 @@ jobs:
           E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
-          HASH="$(eas fingerprint:generate --platform android --build-profile development --json --non-interactive | jq -r '.hash')"
-          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+          HASH="$(node -e "require('@expo/fingerprint').createProjectHashAsync(process.cwd(), { platforms: ['android'] }).then((h) => process.stdout.write(h)).catch((e) => { console.error(e); process.exit(1); })")"
+          if [ -z "$HASH" ]; then
             echo "::error::native fingerprint の取得に失敗しました" >&2
             exit 1
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       # ネイティブフィンガープリント（@expo/fingerprint）を APK キャッシュのキーにする。
-      # eas-cli 経由（eas fingerprint:generate）ではなく @expo/fingerprint の API を直接使う:
+      # eas-cli 経由（eas fingerprint:generate）ではなく @expo/fingerprint の CLI を使う:
       # pnpm-lock.yaml でバージョン固定されるためランをまたいで決定的（eas-version: latest だと
       # 実行時期でアルゴリズムがドリフトしキャッシュが常時 MISS になりうる）で、EAS 認証・ネットワークも
       # 不要。E2E_BUILD / E2E_DEFAULT_LOCALE は app.config.ts の評価に反映され（ExpoConfigLoader が
@@ -87,8 +87,8 @@ jobs:
           E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
-          HASH="$(node -e "require('@expo/fingerprint').createProjectHashAsync(process.cwd(), { platforms: ['android'] }).then((h) => process.stdout.write(h)).catch((e) => { console.error(e); process.exit(1); })")"
-          if [ -z "$HASH" ]; then
+          HASH="$(pnpm exec fingerprint fingerprint:generate --platform android | jq -r '.hash')"
+          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
             echo "::error::native fingerprint の取得に失敗しました" >&2
             exit 1
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,20 +21,26 @@ env:
   MAESTRO_VERSION: '2.6.1'
   ANDROID_API_LEVEL: '34'
   AVD_NAME: e2e
+  # dev-client debug APK の出力/キャッシュ先（fingerprint キャッシュの path と一致させる）
+  APK_PATH: apps/sandbox/build-output/sandbox-e2e-devclient.apk
 
 jobs:
-  # Development Build（Dev Client 入り）を expo run:android でビルド→install→Metro 起動→
-  # アプリ起動まで一括実行し、その上で Maestro E2E を実行する（ローカル開発と同一コマンド）。
-  # E2E_BUILD=true により app.config.ts が dev-client の config plugin を有効化し、
+  # Development Build（Dev Client 入り）の debug APK を eas build --local でビルドし、
+  # emulator に install → Metro（expo start）を起動 → Maestro E2E を実行する。
+  # ビルド成果物(APK)は @expo/fingerprint のハッシュをキーに actions/cache で永続化し、
+  # ネイティブ fingerprint が一致する限り eas build --local を丸ごとスキップする。
+  # main への push では e2e-main.yml の warm ジョブが同じ fingerprint / 同じ profile で
+  # APK を事前にキャッシュへ投入するため、ネイティブ変更の無い（JS のみの）PR は
+  # 初回プッシュから default ブランチのキャッシュにヒットし、ビルドを省略できる。
+  # E2E_BUILD=true により app.config.ts が expo-dev-client の config plugin を有効化し、
   # defaultLaunchURL(http://localhost:8081) で launcher を経由せず Metro へ自動接続する。
-  # EAS / EXPO_TOKEN は不要。
-  # ネイティブフィンガープリントが前回と一致する場合は expo run:android 自体が
-  # Gradle ビルドをスキップしてキャッシュ済みバイナリを再利用する
-  # （apps/sandbox/app.config.ts の buildCacheProvider、下記 actions/cache で永続化）。
+  # ビルドは eas build --local を使うため EXPO_TOKEN（secrets）が必要。
+  # dev-client debug ビルドには eas.json の development プロファイルを再利用する
+  # （developmentClient: true → Android は :app:assembleDebug = APK）。
   # ※ アプリ起動時の Metro バンドル生成（CPU スパイク）で低速 emulator の SystemUI/Launcher が ANR
   #   しないよう、emulator は CI 向け軽量イメージ google_atd を使う（system process が軽く ANR しにくい）。
-  #   コマンドは素の expo run:android のままで、nice や pre-warm 等の小細工は使わない。
-  # Dev Client を含まない（e2e プロファイル / 埋め込み JS）E2E は e2e-main.yml（main への push）で行う。
+  # Dev Client を含まない（e2e プロファイル / 埋め込み JS）release ビルドの E2E は
+  # e2e-main.yml（main への push）で行う。
   # 将来 iOS を対象にする場合は e2e-ios ジョブ（macOS ランナー / simulator）を追加する。
   e2e-android:
     name: E2E (Android)
@@ -48,21 +54,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      # expo run:android のネイティブビルドキャッシュ（apps/sandbox/app.config.ts の
-      # buildCacheProvider）が使うディレクトリを永続化する。fingerprint が前回と一致すれば
-      # expo run:android が Gradle ビルドをスキップしてこの中のバイナリを再利用する。
-      # key は常にユニーク（run_id）にし restore-keys で直近のキャッシュを復元する
-      # 成長型キャッシュとする。固定キーだと actions/cache の「完全一致時は保存しない」仕様により
-      # ネイティブ変更後も更新されなくなるため。異なる fingerprint のエントリは自動削除されず
-      # ディレクトリは増え続けるが、GitHub 側の自動退役に任せる（docs/maestro.md 参照）。
-      - name: Restore native build cache
-        uses: actions/cache@v6
-        with:
-          path: apps/sandbox/.expo/build-cache
-          key: e2e-android-buildcache-${{ github.run_id }}
-          restore-keys: |
-            e2e-android-buildcache-
-
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
@@ -74,6 +65,70 @@ jobs:
 
       - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node
+
+      - name: Setup EAS
+        uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # ネイティブフィンガープリント（@expo/fingerprint）を APK キャッシュのキーにする。
+      # E2E_BUILD / E2E_DEFAULT_LOCALE は app.config.ts が読む env。ビルドと同じ値を渡し、
+      # 同じ build profile（development）で計算することで、PR と e2e-main.yml の warm ジョブで
+      # ハッシュが一致する（fingerprint は JS を含まずネイティブ依存・config のみを対象とするため、
+      # JS のみの変更ではハッシュ不変 → 既存 APK を再利用でき、更新 JS は Metro が配信する）。
+      - name: Compute native fingerprint
+        id: fp
+        working-directory: apps/sandbox
+        env:
+          E2E_BUILD: 'true'
+          E2E_DEFAULT_LOCALE: ja
+        run: |
+          HASH="$(eas fingerprint:generate --platform android --build-profile development --json --non-interactive | jq -r '.hash')"
+          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+            echo "::error::native fingerprint の取得に失敗しました" >&2
+            exit 1
+          fi
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "native fingerprint: $HASH"
+
+      # fingerprint を exact-match キーにした APK キャッシュ。restore-keys は使わない
+      # （fingerprint が変われば別キー = 正しくミスし、下の Build ステップで作り直して保存する）。
+      # arch（x86_64）は fingerprint に含まれないためキーに明示する。将来 arch を増やす場合は
+      # ここを変えれば別キーになり、stale な x86_64 APK のヒットを防げる。
+      - name: Cache dev-client APK
+        id: cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.APK_PATH }}
+          key: e2e-android-devclient-apk-x86_64-${{ steps.fp.outputs.hash }}
+
+      # キャッシュミス時のみ eas build --local で dev-client debug APK をビルドする。
+      # x86_64 のみビルドして emulator の arch と一致させる（install 可能・ビルド時間短縮）。
+      - name: Build dev-client APK (eas build --local)
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: apps/sandbox
+        env:
+          ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
+          E2E_BUILD: 'true'
+          E2E_DEFAULT_LOCALE: ja
+        run: |
+          eas build --local --profile development --platform android \
+            --non-interactive --output ./build-output/sandbox-e2e-devclient.apk
+
+      - name: Summarize APK cache result
+        if: always()
+        run: |
+          if [ -z "${{ steps.fp.outputs.hash }}" ]; then
+            echo "### dev-client APK cache: 判定不能（fingerprint の取得に失敗）" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
+            echo "### dev-client APK cache: HIT（eas build --local をスキップ）" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "fingerprint: \`${{ steps.fp.outputs.hash }}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### dev-client APK cache: MISS（eas build --local を実行 → キャッシュに保存）" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "fingerprint: \`${{ steps.fp.outputs.hash }}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Install Maestro CLI
         run: |
@@ -113,11 +168,11 @@ jobs:
 
       - name: Run Maestro E2E
         env:
-          # x86_64 のみビルドして emulator の arch と一致させる（ビルド時間短縮）
-          ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
           # E2E ビルドはアプリの言語既定値を ja に固定する（emulator ロケールは既定 en-US のまま）。
-          # app.config.ts が extra.e2eDefaultLocale に埋め込み、i18n/locale.ts の
-          # getStoredLocalePreference() の（保存値が無いときの）フォールバックとして参照される。
+          # dev-client では Constants.expoConfig は Metro が配信する manifest 由来のため、
+          # expo start にも E2E_BUILD / E2E_DEFAULT_LOCALE を渡して app.config を同条件で評価させる
+          # （i18n/locale.ts の getStoredLocalePreference() のフォールバックが ja になる）。
+          E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
           # emulator をバックグラウンド起動（テスト端末ロケールは既定の en-US を使う）
@@ -144,41 +199,29 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global animator_duration_scale 0
 
-          # Development Build を expo run:android でビルド→install→Metro 起動→adb reverse→
-          # アプリ起動まで一括実行する（ローカル開発と同一コマンド）。Metro はテスト中ずっと
-          # 生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
-          E2E_BUILD=true pnpm --dir apps/sandbox exec expo run:android > "$RUNNER_TEMP/expo-run.log" 2>&1 &
-          EXPO_RUN_PID=$!
-          echo "EXPO_RUN_PID=$EXPO_RUN_PID" >> "$GITHUB_ENV"
+          # ビルド済み（キャッシュ or eas build --local）の dev-client debug APK を install する
+          adb install -r "$APK_PATH"
 
-          # ビルド→install→アプリ起動（MainActivity）まで待つ。expo run が途中で死んだら失敗させる
-          timeout 1200 bash -c '
-            until adb shell dumpsys activity activities 2>/dev/null | tr -d "\r" | grep -q "com.yamibeta.sandbox/.MainActivity"; do
-              kill -0 '"$EXPO_RUN_PID"' 2>/dev/null || { echo "expo run:android が予期せず終了しました"; exit 1; }
-              sleep 5
+          # Metro を background 起動する。Dev Client は defaultLaunchURL(http://localhost:8081) で
+          # 起動時に Metro へ自動接続するため、初回の明示 launch は不要（maestro の launchApp が担う）。
+          # Metro はテスト中ずっと生かす必要があるため PID は cleanup 用に記録する。
+          pnpm --dir apps/sandbox exec expo start > "$RUNNER_TEMP/expo-start.log" 2>&1 &
+          EXPO_START_PID=$!
+          echo "EXPO_START_PID=$EXPO_START_PID" >> "$GITHUB_ENV"
+
+          # device → host の Metro へポート転送（Dev Client が localhost:8081 に到達できるようにする）
+          adb reverse tcp:8081 tcp:8081
+
+          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）。
+          # expo start が途中で死んだら 120 秒待たず即失敗させる（診断の高速化）。
+          timeout 120 bash -c '
+            until curl -fsS http://localhost:8081/status 2>/dev/null | grep -q "packager-status:running"; do
+              kill -0 '"$EXPO_START_PID"' 2>/dev/null || { echo "expo start が予期せず終了しました"; exit 1; }
+              sleep 2
             done'
-          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）
-          timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
 
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
-
-      # ネイティブビルドキャッシュがヒットしたか確認できるよう expo-run.log を要約する。
-      # grep パターンは node_modules/@expo/local-build-cache-provider・
-      # node_modules/@expo/cli の実際のログ文言に基づく。
-      - name: Summarize native build cache result
-        if: always()
-        run: |
-          LOG="$RUNNER_TEMP/expo-run.log"
-          if [ ! -f "$LOG" ]; then
-            echo "### Native build cache: expo-run.log が見つかりません" >> "$GITHUB_STEP_SUMMARY"
-          elif grep -qE 'Installing .*\.expo/build-cache/' "$LOG"; then
-            echo "### Native build cache: HIT（ネイティブビルドをスキップ）" >> "$GITHUB_STEP_SUMMARY"
-          elif grep -q 'Copying build to local cache' "$LOG"; then
-            echo "### Native build cache: MISS（フルビルド実行 → 今回の成果をキャッシュに追加）" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "### Native build cache: 判定不能（expo-run.log を確認）" >> "$GITHUB_STEP_SUMMARY"
-          fi
 
       # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
       # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）
@@ -204,8 +247,7 @@ jobs:
         if: always()
         run: |
           adb reverse --remove-all || true
-          kill "$EXPO_RUN_PID" 2>/dev/null || true
-          pkill -f "expo run:android" 2>/dev/null || true
+          kill "$EXPO_START_PID" 2>/dev/null || true
           pkill -f "expo start" 2>/dev/null || true
 
       # 成功・失敗にかかわらずレポート・スクショ/録画/ログ・診断（画面状態）を保存する
@@ -217,7 +259,7 @@ jobs:
           path: |
             maestro-report.xml
             maestro-debug
-            ${{ runner.temp }}/expo-run.log
+            ${{ runner.temp }}/expo-start.log
             ${{ runner.temp }}/diag
           retention-days: 7
           if-no-files-found: warn

--- a/apps/sandbox/.fingerprintignore
+++ b/apps/sandbox/.fingerprintignore
@@ -1,25 +1,20 @@
 # --- @react-native-masked-view/masked-view の AndroidManifest.xml ---
 #
-# 症状: ネイティブビルドキャッシュ（apps/sandbox/app.config.ts の buildCacheProvider）が
-# 常に MISS になり、キャッシュが一切効かない。
+# このファイルは Gradle ビルド実行中に書き換わる（pnpm install 直後・expo prebuild 直後の内容は
+# 同一で、Gradle ビルド後にだけ変化することを実際の CI 実行で確認済み）。具体的には
+# `package="org.reactnative.maskedview"` 属性が取り除かれ、跡地に二重スペースが残る
+# （<manifest  xmlns:android=...> ）。XML をパースして書き直したのではなく単純な文字列置換の痕跡で、
+# このモジュールに対して実行される Gradle タスクはすべて AGP（Android Gradle Plugin）標準の組み込み
+# タスクのみだった（Expo/RN 独自のカスタムタスクは無かった）ことから、AGP 自身（あるいは Gradle の
+# ビルドキャッシュ機構）による挙動と推測される。正確な実装箇所は AGP がクローズドソースのため未特定。
 #
-# 原因: このファイルは Gradle ビルド実行中に書き換わる（pnpm install 直後・
-# expo prebuild 直後の内容は同一で、Gradle ビルド後にだけ変化することを実際の CI 実行で
-# 確認済み）。具体的には `package="org.reactnative.maskedview"` 属性が取り除かれ、
-# 跡地に二重スペースが残る（<manifest  xmlns:android=...> ）。XML をパースして
-# 書き直したのではなく単純な文字列置換の痕跡で、このモジュールに対して実行される
-# Gradle タスクはすべて AGP（Android Gradle Plugin）標準の組み込みタスクのみだった
-# （Expo/RN 独自のカスタムタスクは無かった）ことから、AGP 自身（あるいは Gradle の
-# ビルドキャッシュ機構）による挙動と推測される。正確な実装箇所は AGP がクローズド
-# ソースのため特定できていない。
+# 影響: E2E の dev-client APK キャッシュは、ビルド前に `eas fingerprint:generate`（@expo/fingerprint）
+# で計算したハッシュをキーにする（e2e.yml の PR ジョブと e2e-main.yml の warm ジョブが同一ハッシュを
+# 出すことが初回ヒットの前提）。この churning ファイルをフィンガープリントに含めると、Gradle ビルドを
+# 走らせた runner 上で内容が変わりハッシュがドリフトしうるため、除外して内容の変化を無視する。
 #
-# @expo/fingerprint はビルド前（resolveBuildCache）とビルド後（uploadBuildCache）の
-# 2回、別々にこのファイルを含むフィンガープリントを計算する。書き換えが起きるため
-# 同一コミット・同一実行内でもこの2回の値が一致せず、過去にアップロードされた
-# キャッシュには原理的に絶対ヒットしない。
-#
-# 補足: @react-native-masked-view/masked-view は Expo 公式パッケージではなく、
-# expo-router が内部にバンドルしている React Navigation 由来の画面遷移コンポーネント
+# 補足: @react-native-masked-view/masked-view は Expo 公式パッケージではなく、expo-router が内部に
+# バンドルしている React Navigation 由来の画面遷移コンポーネント
 # （expo-router/build/react-navigation/elements/）が使うサードパーティパッケージ。
 # 原因が判明している expo-* パッケージ群には同様の差分は見られなかった。
 #

--- a/apps/sandbox/.gitignore
+++ b/apps/sandbox/.gitignore
@@ -13,6 +13,9 @@ dist/
 web-build/
 expo-env.d.ts
 
+# eas build --local の出力（E2E ビルド成果物。CI では actions/cache 経由で扱う）
+build-output/
+
 # Native
 .kotlin/
 *.orig.*

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -1,7 +1,7 @@
 # アプリ起動〜ホーム画面の表示を確認する最小スモークテスト。
 # このフローへの変更はネイティブ部分（依存関係・ネイティブコード・config plugin・app.json/
-# app.config の設定）を伴わないため、CI のネイティブビルドキャッシュ（docs/maestro.md 参照）が
-# ヒットし expo run:android の Gradle ビルドがスキップされる想定。
+# app.config の設定）を伴わないため、ネイティブ fingerprint は変わらず、CI の dev-client APK
+# キャッシュ（docs/maestro.md 参照）がヒットして eas build --local がスキップされる想定。
 # emulator ロケールは固定せず（既定 en-US）、E2E ビルドはアプリの言語既定値を ja に固定する
 # （E2E_DEFAULT_LOCALE=ja / .github/workflows/e2e.yml・e2e-main.yml・src/i18n/locale.ts 参照）。
 # 表示テキストは lingui の <Trans>（sourceLocale=ja）。

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -10,17 +10,8 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 // - skipOnboarding / showMenuAtLaunch / toolsButton: オンボーディング・起動時メニュー・
 //   フローティングツールボタンが assert を阻害しないよう無効化する
 //
-// buildCacheProvider: expo run:android/ios のネイティブフィンガープリントが前回と一致する
-// 場合、Gradle ビルドをスキップしローカルキャッシュ（apps/sandbox/.expo/build-cache）済みの
-// バイナリを再利用させる。CI（e2e.yml）側で actions/cache によりこのディレクトリを永続化する。
-// 値は必ずオブジェクト形式で指定すること（生文字列は @expo/cli が
-// "Invalid build cache provider" として拒否する）。
-// plugin の "expo/local-build-cache-provider" は expo パッケージが公開しているサブパス
-// （node_modules/expo/local-build-cache-provider.js。実体は @expo/local-build-cache-provider
-// への re-export）。スコープ付きパッケージ名 "@expo/local-build-cache-provider" を直接指定
-// しても現状は解決できるが、これは apps/sandbox の直接依存ではなく expo 経由の推移依存
-// （pnpm-lock.yaml にのみ存在）のため、意図して "expo/..." のサブパス経由で参照する。
-//
+// E2E の CI では dev-client debug APK を eas build --local でビルドし、@expo/fingerprint の
+// ハッシュをキーに APK を actions/cache へ保存して再利用する（buildCacheProvider には依存しない）。
 // 詳細は docs/maestro.md を参照。
 export default ({ config }: ConfigContext): ExpoConfig => {
   const plugins = [...(config.plugins ?? [])];
@@ -44,7 +35,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     name: config.name ?? "sandbox",
     slug: config.slug ?? "sandbox",
     plugins,
-    ...(isE2EBuild ? { buildCacheProvider: { plugin: "expo/local-build-cache-provider" } } : {}),
     extra: {
       ...config.extra,
       // E2E ビルドでアプリの表示言語を固定するための既定値（src/i18n/locale.ts が参照）。

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -154,8 +154,8 @@ maestro test apps/sandbox/.maestro/
   `secrets.EXPO_TOKEN` が fork/dependabot には渡らないため）。
 - サードパーティ Action は使わず、GitHub / Gradle / Expo / pnpm の公式 Action と、ubuntu-latest に
   プリインストール済みの Android SDK ツール（`sdkmanager` / `avdmanager` / `emulator` / `adb`）のみで構成。
-- **ステップ順**: `Setup EAS`（`EXPO_TOKEN`）→ fingerprint 計算（`@expo/fingerprint` の
-  `createProjectHashAsync` を API 直呼び。pnpm-lock.yaml 固定で決定的・EAS 認証不要）→
+- **ステップ順**: `Setup EAS`（`EXPO_TOKEN`）→ fingerprint 計算（`@expo/fingerprint` の CLI
+  `pnpm exec fingerprint fingerprint:generate --platform android`。pnpm-lock.yaml 固定で決定的・EAS 認証不要）→
   `actions/cache`（キー `e2e-android-devclient-apk-x86_64-<hash>`）→ ミス時のみ
   `eas build --local --profile development`（dev-client debug APK）→ emulator 起動 →
   `adb install -r` → `expo start`（Metro を background 起動）→ `adb reverse tcp:8081 tcp:8081` →

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -154,7 +154,8 @@ maestro test apps/sandbox/.maestro/
   `secrets.EXPO_TOKEN` が fork/dependabot には渡らないため）。
 - サードパーティ Action は使わず、GitHub / Gradle / Expo / pnpm の公式 Action と、ubuntu-latest に
   プリインストール済みの Android SDK ツール（`sdkmanager` / `avdmanager` / `emulator` / `adb`）のみで構成。
-- **ステップ順**: `Setup EAS`（`EXPO_TOKEN`）→ fingerprint 計算（`eas fingerprint:generate --json`）→
+- **ステップ順**: `Setup EAS`（`EXPO_TOKEN`）→ fingerprint 計算（`@expo/fingerprint` の
+  `createProjectHashAsync` を API 直呼び。pnpm-lock.yaml 固定で決定的・EAS 認証不要）→
   `actions/cache`（キー `e2e-android-devclient-apk-x86_64-<hash>`）→ ミス時のみ
   `eas build --local --profile development`（dev-client debug APK）→ emulator 起動 →
   `adb install -r` → `expo start`（Metro を background 起動）→ `adb reverse tcp:8081 tcp:8081` →

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -58,7 +58,7 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
 | `apps/sandbox/eas.json` の `development` プロファイル | PR の dev-client debug E2E ビルドに再利用（`developmentClient: true` → Android は `:app:assembleDebug` = APK） |
 | `apps/sandbox/eas.json` の `e2e` プロファイル | 非 Dev Client 用（main の release E2E）ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
 | `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
-| `.github/workflows/e2e.yml` | PR ごとに「fingerprint 計算 → APK キャッシュ復元／（ミス時）`eas build --local --profile development` → emulator 起動 → `adb install` → `expo start`（Metro）→ maestro test」を実行 |
+| `.github/workflows/e2e.yml` | PR ごとに「fingerprint 計算 → APK キャッシュ復元／（ミス時）`eas build --local --profile development` → emulator 起動 → `expo run:android --binary <APK>`（install→Metro→`adb reverse`→dev-client 起動）→ maestro test」を実行 |
 | `.github/workflows/e2e-main.yml` | main への push ごとに、release E2E ジョブ（`eas build --local --profile e2e` → install → maestro）と dev-client APK 温めジョブ（`warm-devclient-cache`。fingerprint → `eas build --local --profile development` → キャッシュ保存。build のみ）を並列実行 |
 
 ## フローの書き方
@@ -120,14 +120,20 @@ E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec expo run:andro
 maestro test apps/sandbox/.maestro/
 ```
 
-> CI（`e2e.yml`）は同じ dev-client debug ビルドを `eas build --local --profile development` で作り、
-> `adb install` → `expo start`（Metro）→ `adb reverse` の順で実行する（emulator を伴わない main の
-> 温めジョブと同一のビルドを再利用するため）。CI と同じ経路を手元で再現したい場合は次を使う:
+> CI（`e2e.yml`）は同じ dev-client debug ビルドを `eas build --local --profile development` で作り
+> （emulator を伴わない main の温めジョブと同一のビルドを再利用）、その APK を
+> `expo run:android --binary <APK>` に渡して install→Metro→`adb reverse`→dev-client 起動まで行う
+> （`--binary` で Gradle ビルドはスキップ。素の `adb install` + `expo start` では dev-client が Metro に
+> 接続せず黒画面になるため、接続確立を含む run:android の launch ロジックを使う）。CI と同じ経路を手元で
+> 再現したい場合は、上の Dev Client 経路（`expo run:android`）をそのまま使えばよい。APK を明示的に作るなら:
 >
 > ```bash
 > E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec eas build --local \
 >   --profile development --platform android --non-interactive \
 >   --output ./build-output/sandbox-e2e-devclient.apk
+> # 上記 APK を使って install→Metro→起動:
+> E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec \
+>   expo run:android --binary ./build-output/sandbox-e2e-devclient.apk
 > ```
 
 ### 非 Dev Client 経路（main 互換の回帰確認）
@@ -160,13 +166,16 @@ maestro test apps/sandbox/.maestro/
   `pnpm exec fingerprint fingerprint:generate --platform android`。pnpm-lock.yaml 固定で決定的・EAS 認証不要）→
   `actions/cache`（キー `e2e-android-devclient-apk-x86_64-<hash>`）→ ミス時のみ
   `eas build --local --profile development`（dev-client debug APK）→ emulator 起動 →
-  `adb install -r` → `expo start`（Metro を background 起動）→ `adb reverse tcp:8081 tcp:8081` →
-  Metro readiness 待ち → `maestro test`。テスト後は `expo start`（Metro）を kill する。
-- Dev Client は `defaultLaunchURL` により起動時に `localhost:8081` の Metro へ自動接続するため、
-  明示的な初回 launch は不要（maestro の `launchApp` が起動を担う）。
-- `E2E_BUILD` / `E2E_DEFAULT_LOCALE` は fingerprint 計算・ビルド・`expo start` の各ステップに step `env`
-  として同じ値（`true` / `ja`）を渡す。dev-client では `Constants.expoConfig` が Metro 配信の manifest
-  由来のため、`expo start` にも渡して app.config を同条件で評価させる（既定言語が `ja` になる）。
+  `expo run:android --binary <APK>`（install→Metro 起動→`adb reverse`→dev-client 起動を一括。`--binary` で
+  Gradle ビルドはスキップ）→ アプリ起動（MainActivity）と Metro readiness を待って `maestro test`。
+  テスト後は `expo run:android`（Metro 含む）を kill する。
+- **`adb install` + `expo start` の手組みは使わない**。dev-client は素の `launchApp` では `defaultLaunchURL`
+  の自動接続が効かず黒画面になる（Metro に bundle を要求しない）ため、接続確立を含む `expo run:android` の
+  launch ロジック（`--binary` でビルドのみスキップ）を再利用する。dev-client 起動後の Metro 接続確立は
+  run:android が担い、maestro の `launchApp`（clearState）はその接続を再利用する。
+- `E2E_BUILD` / `E2E_DEFAULT_LOCALE` は fingerprint 計算・ビルド・`expo run:android` の各ステップに
+  step `env` として同じ値（`true` / `ja`）を渡す。dev-client では `Constants.expoConfig` が Metro 配信の
+  manifest 由来のため、run:android が起動する Metro にも渡して app.config を同条件で評価させる（既定言語が `ja`）。
 - アプリの言語は `E2E_DEFAULT_LOCALE=ja` で固定するため、adb によるロケール固定は行わない
   （emulator ロケールは既定 en-US のまま）。
 - **ANR 対策に CI 用軽量イメージ `google_atd`（Automated Test Device）を使う**。低速な CI emulator
@@ -176,7 +185,7 @@ maestro test apps/sandbox/.maestro/
   ANR しにくい。
 - `ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64` でビルド ABI を emulator の `arch` と一致させている
   （install 可能・ビルド時間短縮）。emulator には `-memory 6144 -cores 4` を付与。
-- 失敗時も `maestro-report.xml`（JUnit）・`--debug-output` のスクショ/録画/ログ・`expo-start.log`・
+- 失敗時も `maestro-report.xml`（JUnit）・`--debug-output` のスクショ/録画/ログ・`expo-run.log`・
   画面診断（スクショ/ロケール/前面 activity/UI テキスト）を artifact に保存する。
 - Maestro CLI は再現性のためバージョン固定（`MAESTRO_VERSION`）。更新は意図的に PR で上げる。
 - **APK ビルドキャッシュ**: fingerprint（`@expo/fingerprint`）のハッシュを **exact-match キー**

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -6,13 +6,17 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
 
 ## 方針
 
-- **EAS のビルドクレジットは PR では使わない**。PR は `expo run:android`（GitHub Actions の Linux ランナー上で
-  ローカル gradle ビルド）で完結し、EAS リモートビルドや `EXPO_TOKEN` に依存しない。main ブランチ用の
-  非 Dev Client `e2e` プロファイルのみ `eas build --local` を使う（`EXPO_TOKEN` が必要）。
-- **PR は Development Build（Dev Client / Metro 接続）でテストする**。ローカル開発（`expo start` +
-  `expo run:ios/android`）と前提を揃え、release ではなく debug ビルドにすることでビルド時間も短縮する。
-  Dev Client（`developmentClient: true`）は本来起動時に Metro dev server を探す launcher 画面が出るが、
-  **`defaultLaunchURL` を焼き込んで Metro へ自動接続**させることで launcher を経由せず起動する。
+- **EAS のリモートビルドクレジットは使わない**。ビルドはすべて `eas build --local`（GitHub Actions の
+  Linux ランナー上でローカル gradle ビルド）で完結し、リモートビルド分を消費しない。ただしローカル
+  ビルドでも EAS への認証（`EXPO_TOKEN`）は必要（プロジェクト `@account/slug` の存在確認で EAS と通信する
+  ため）。PR（dev-client debug / `development` プロファイル）・main の release E2E（`e2e` プロファイル）・
+  main の APK 温めジョブ（dev-client / `development`）いずれも `secrets.EXPO_TOKEN` を使う。
+- **PR は Development Build（Dev Client / Metro 接続）でテストする**。ローカル開発と前提を揃え、release
+  ではなく debug ビルドにすることでビルド時間も短縮する。dev-client debug ビルドには eas.json の
+  `development` プロファイル（`developmentClient: true` → Android は `:app:assembleDebug` = APK）を再利用し、
+  CI では `eas build --local --profile development` でビルドする。Dev Client（`developmentClient: true`）は
+  本来起動時に Metro dev server を探す launcher 画面が出るが、**`defaultLaunchURL` を焼き込んで Metro へ
+  自動接続**させることで launcher を経由せず起動する。
 - **config plugin の設定は E2E ビルド時のみ適用する**。`apps/sandbox/app.config.ts`（dynamic config）が
   `E2E_BUILD=true` のときだけ `expo-dev-client` plugin を追記する。これにより通常の `expo run` や配布用
   dev build（`eas-build.yml` の `development` プロファイル）の開発体験には影響しない。E2E では次を設定:
@@ -28,16 +32,18 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
   は release variant でビルドされ、`lintVitalRelease`（lint）が CI ランナーのメモリを使い切って
   `OutOfMemoryError` で落ちる。lint は E2E ビルドに不要（品質チェックは oxlint / expo lint で別途実施）なため、
   `e2e` プロファイルの `android.gradleCommand` を `:app:assembleRelease -x lintVitalRelease` にして除外している。
-- **ネイティブ部分に変更が無ければ Gradle ビルドをスキップする**。`apps/sandbox/app.config.ts` が
-  `E2E_BUILD=true` のときだけ `buildCacheProvider` に組み込みのローカル provider
-  （`expo/local-build-cache-provider`）を設定する。`expo run:android` はネイティブのフィンガープリント
-  （`@expo/fingerprint`。依存関係・ネイティブコード・config plugin・app.json/app.config の設定が対象。
-  JS/TSX のアプリケーションソースは対象外）が前回と一致すればキャッシュ済みバイナリの install・Metro 起動まで
-  内部で自動的に行い、フルビルドをスキップする。CI では `apps/sandbox/.expo/build-cache`（既定のキャッシュ
-  保存先）を `actions/cache` で永続化する。多くの PR は JS のみの変更でネイティブ部分は変わらないため、
-  この場合は毎回のフルビルドを避けられる。値は必ずオブジェクト形式 `{ plugin: "..." }` で指定すること
-  （生文字列は `@expo/cli` に `Invalid build cache provider` として拒否される）。
-  - `apps/sandbox/.fingerprintignore` でビルド中に内容が変わり誤検出を招く既知のファイルを
+- **ネイティブ部分に変更が無ければビルドをスキップする**。dev-client debug APK を
+  `eas build --local --profile development` でビルドし、`@expo/fingerprint` のハッシュ（依存関係・
+  ネイティブコード・config plugin・app.json/app.config の設定が対象。JS/TSX のアプリケーションソースは
+  対象外）を **exact-match キー**にした `actions/cache` で APK を永続化する。fingerprint が一致すれば
+  `eas build --local` を丸ごとスキップして install に進む。多くの PR は JS のみの変更でネイティブ部分は
+  変わらないため、この場合はビルドを避けられ、更新された JS は Metro（Dev Client 接続）が配信する。
+  - **GitHub Actions のキャッシュはブランチスコープ**で、新規 PR ブランチが復元できるのは default ブランチ
+    （main）が書き込んだキャッシュのみ。そのため `e2e-main.yml` に **dev-client APK 温めジョブ**
+    （`warm-devclient-cache`）を置き、main への push ごとに PR と同一 fingerprint / 同一 profile で APK を
+    先にキャッシュへ投入する。これによりネイティブ変更の無い PR は**初回プッシュから**ヒットできる。
+    fingerprint が変わる（ネイティブ変更のある）PR のみ、そのコミットで一度ビルドが発生する。
+  - `apps/sandbox/.fingerprintignore` でビルド中に内容が変わり誤検出（無駄な MISS）を招く既知のファイルを
     除外している。原因・調査内容はファイル内のコメントを参照。今後同様のパッケージが
     見つかった場合はこのファイルに追記する。
 
@@ -45,12 +51,13 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
 
 | ファイル | 役割 |
 | --- | --- |
-| `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）と `buildCacheProvider`（ネイティブビルドキャッシュ）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
-| `apps/sandbox/.fingerprintignore` | ネイティブビルドキャッシュのフィンガープリント計算から除外するパス。ビルドで内容が変わり無限に MISS を招く既知のファイル（`@react-native-masked-view/masked-view` の `AndroidManifest.xml` 等）を列挙 |
-| `apps/sandbox/eas.json` の `e2e` プロファイル | 非 Dev Client 用 E2E ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
+| `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
+| `apps/sandbox/.fingerprintignore` | dev-client APK キャッシュのキーに使う `@expo/fingerprint` の計算から除外するパス。ビルドで内容が変わり無駄な MISS を招く既知のファイル（`@react-native-masked-view/masked-view` の `AndroidManifest.xml` 等）を列挙 |
+| `apps/sandbox/eas.json` の `development` プロファイル | PR の dev-client debug E2E ビルドに再利用（`developmentClient: true` → Android は `:app:assembleDebug` = APK） |
+| `apps/sandbox/eas.json` の `e2e` プロファイル | 非 Dev Client 用（main の release E2E）ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
 | `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
-| `.github/workflows/e2e.yml` | PR ごとに「emulator 起動 → `E2E_BUILD=true expo run:android`（build→install→Metro→接続）→ maestro test」を1ジョブで実行 |
-| `.github/workflows/e2e-main.yml` | main への push ごとに「`eas build --local --profile e2e`（release / 埋め込み JS）→ emulator 起動 → APK install → maestro test」を1ジョブで実行 |
+| `.github/workflows/e2e.yml` | PR ごとに「fingerprint 計算 → APK キャッシュ復元／（ミス時）`eas build --local --profile development` → emulator 起動 → `adb install` → `expo start`（Metro）→ maestro test」を実行 |
+| `.github/workflows/e2e-main.yml` | main への push ごとに、release E2E ジョブ（`eas build --local --profile e2e` → install → maestro）と dev-client APK 温めジョブ（`warm-devclient-cache`。fingerprint → `eas build --local --profile development` → キャッシュ保存。build のみ）を並列実行 |
 
 ## フローの書き方
 
@@ -97,7 +104,7 @@ assert（`ホーム` / `ナビゲーションパターン` / `コンポーネン
 アプリ言語は `E2E_DEFAULT_LOCALE=ja` で固定する）** が必要。
 Maestro CLI が未インストールなら `curl -fsSL "https://get.maestro.mobile.dev" | bash`。
 
-### Dev Client 経路（PR と同条件・推奨）
+### Dev Client 経路（推奨・ローカル開発と同一）
 
 `E2E_BUILD=true` を付けて `expo run:android` すると、`app.config.ts` が E2E 用 config plugin を
 有効化した Development Build をビルドし、Metro 起動・install・`adb reverse`・接続まで自動で行う。
@@ -110,6 +117,16 @@ E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec expo run:andro
 # 2. 別ターミナルでフローを実行（Dev Client は defaultLaunchURL で Metro に自動接続）
 maestro test apps/sandbox/.maestro/
 ```
+
+> CI（`e2e.yml`）は同じ dev-client debug ビルドを `eas build --local --profile development` で作り、
+> `adb install` → `expo start`（Metro）→ `adb reverse` の順で実行する（emulator を伴わない main の
+> 温めジョブと同一のビルドを再利用するため）。CI と同じ経路を手元で再現したい場合は次を使う:
+>
+> ```bash
+> E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec eas build --local \
+>   --profile development --platform android --non-interactive \
+>   --output ./build-output/sandbox-e2e-devclient.apk
+> ```
 
 ### 非 Dev Client 経路（main 互換の回帰確認）
 
@@ -133,33 +150,38 @@ maestro test apps/sandbox/.maestro/
 
 ## CI（`.github/workflows/e2e.yml`）
 
-- トリガー: `apps/sandbox/**` などを変更する PR（dependabot は除外）。
+- トリガー: `apps/sandbox/**` などを変更する PR（dependabot は除外。`eas build --local` に必要な
+  `secrets.EXPO_TOKEN` が fork/dependabot には渡らないため）。
 - サードパーティ Action は使わず、GitHub / Gradle / Expo / pnpm の公式 Action と、ubuntu-latest に
   プリインストール済みの Android SDK ツール（`sdkmanager` / `avdmanager` / `emulator` / `adb`）のみで構成。
-- emulator 起動（ロケールは既定 en-US のまま）の後、`E2E_BUILD=true E2E_DEFAULT_LOCALE=ja
-  expo run:android` を background 起動し、build→install→Metro 起動→`adb reverse`→アプリ起動までを
-  一括で行う（ローカル開発と同一コマンド。EAS / EXPO_TOKEN は不要）。アプリ起動（MainActivity）と
-  Metro readiness を待って maestro を実行し、テスト後は expo run（Metro 含む）を kill する。
+- **ステップ順**: `Setup EAS`（`EXPO_TOKEN`）→ fingerprint 計算（`eas fingerprint:generate --json`）→
+  `actions/cache`（キー `e2e-android-devclient-apk-x86_64-<hash>`）→ ミス時のみ
+  `eas build --local --profile development`（dev-client debug APK）→ emulator 起動 →
+  `adb install -r` → `expo start`（Metro を background 起動）→ `adb reverse tcp:8081 tcp:8081` →
+  Metro readiness 待ち → `maestro test`。テスト後は `expo start`（Metro）を kill する。
+- Dev Client は `defaultLaunchURL` により起動時に `localhost:8081` の Metro へ自動接続するため、
+  明示的な初回 launch は不要（maestro の `launchApp` が起動を担う）。
+- `E2E_BUILD` / `E2E_DEFAULT_LOCALE` は fingerprint 計算・ビルド・`expo start` の各ステップに step `env`
+  として同じ値（`true` / `ja`）を渡す。dev-client では `Constants.expoConfig` が Metro 配信の manifest
+  由来のため、`expo start` にも渡して app.config を同条件で評価させる（既定言語が `ja` になる）。
 - アプリの言語は `E2E_DEFAULT_LOCALE=ja` で固定するため、adb によるロケール固定は行わない
   （emulator ロケールは既定 en-US のまま）。
 - **ANR 対策に CI 用軽量イメージ `google_atd`（Automated Test Device）を使う**。低速な CI emulator
   （swiftshader）ではアプリ起動時の初回バンドル生成（CPU スパイク）が emulator を飢えさせ、
   通常イメージ（`google_apis`）だと SystemUI/Launcher が ANR してテストを阻害する。ATD は不要な
   システムアプリ/サービスを削った軽量イメージで、同じ CPU スパイク下でもシステムプロセスが応答しやすく
-  ANR しにくい。コマンドは素の `expo run:android` のままで、`nice` や pre-warm 等の小細工は使わない。
-- `ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64` でビルド ABI を emulator の `arch` と一致させている。
-  emulator には `-memory 6144 -cores 4` を付与。
-- 失敗時も `maestro-report.xml`（JUnit）・`--debug-output` のスクショ/録画/ログ・`expo-run.log`・
+  ANR しにくい。
+- `ORG_GRADLE_PROJECT_reactNativeArchitectures=x86_64` でビルド ABI を emulator の `arch` と一致させている
+  （install 可能・ビルド時間短縮）。emulator には `-memory 6144 -cores 4` を付与。
+- 失敗時も `maestro-report.xml`（JUnit）・`--debug-output` のスクショ/録画/ログ・`expo-start.log`・
   画面診断（スクショ/ロケール/前面 activity/UI テキスト）を artifact に保存する。
 - Maestro CLI は再現性のためバージョン固定（`MAESTRO_VERSION`）。更新は意図的に PR で上げる。
-- **ネイティブビルドキャッシュ**（`buildCacheProvider`）が使う `apps/sandbox/.expo/build-cache` を
-  `actions/cache` で永続化する（`Restore native build cache` ステップ）。key は `github.run_id` で
-  常にユニークにし `restore-keys` で直近のキャッシュを復元する成長型キャッシュとしている。固定キーだと
-  `actions/cache` の「完全一致時は保存しない」仕様により、ネイティブ変更後も二度と更新されなくなるため。
-  ヒット/ミスの判定は `expo-run.log` を要約する `Summarize native build cache result` ステップが
-  Job Summary に表示する。異なるフィンガープリントのキャッシュエントリは自動削除されず
-  `.expo/build-cache` は増え続けるが、GitHub 側の自動退役に任せている。キャッシュミス時は通常の
-  フルビルドに安全にフォールバックする。
+- **APK ビルドキャッシュ**: fingerprint（`@expo/fingerprint`）のハッシュを **exact-match キー**
+  （`e2e-android-devclient-apk-x86_64-<hash>`）にして `actions/cache` でビルド済み APK を永続化する。fingerprint が
+  変われば別キーになり、正しくミスして `eas build --local` で作り直し保存する（成長型キャッシュや
+  `restore-keys` は使わない）。ヒット/ミスは `Summarize APK cache result` ステップが Job Summary に表示する。
+  新規 PR ブランチが初回から復元できるよう、キャッシュは `e2e-main.yml` の温めジョブが main で先に投入する
+  （下記）。キャッシュミス時は `eas build --local` に安全にフォールバックする。
 
 ## CI（`.github/workflows/e2e-main.yml`）
 
@@ -169,22 +191,31 @@ maestro test apps/sandbox/.maestro/
   `.github/actions/setup-eas` が明示エラーで失敗し main の E2E が恒常的に失敗するノイズに
   なりうるため、`e2e.yml` の dependabot 除外と同様に `if: github.actor != 'dependabot[bot]'`
   でジョブごと skip している。
-- ビルドは `eas build --local --profile e2e --platform android`（本番相当の release ビルド・
-  Dev Client 無し・埋め込み JS）で行う。`E2E_BUILD` は設定しない（`E2E_DEFAULT_LOCALE=ja` のみ設定）。
-  設定すると `app.config.ts` が `expo-dev-client` plugin と `buildCacheProvider` を有効化してしまい
-  Dev Client が混入するため。EAS の認証には `.github/actions/setup-eas`（`secrets.EXPO_TOKEN`）を使う。
-- Metro は使わないため、`expo run:android` のような build→install→起動の自動化は無い。ビルドした APK を
-  `adb install` するだけで、アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` の `launchApp` に
-  任せる（maestro test 実行前に明示的に起動する必要は無い）。
-- `e2e.yml` が使うネイティブビルドキャッシュ（`buildCacheProvider`）は使わない（上記の通り
-  `E2E_BUILD` を設定しないため）。そのため毎回フルの release ビルド相当になる。
+- **2 つのジョブを並列実行する**。目的が異なる（release 検証 vs dev-client キャッシュ温め）ため独立させる。
+- **`e2e-android`（release E2E ジョブ）**:
+  - ビルドは `eas build --local --profile e2e --platform android`（本番相当の release ビルド・
+    Dev Client 無し・埋め込み JS）で行う。`E2E_BUILD` は設定しない（`E2E_DEFAULT_LOCALE=ja` のみ設定）。
+    設定すると `app.config.ts` が `expo-dev-client` plugin を有効化して Dev Client が混入するため。
+    EAS の認証には `.github/actions/setup-eas`（`secrets.EXPO_TOKEN`）を使う。
+  - Metro は使わないため、build→install→起動の自動化は無い。ビルドした APK を `adb install` するだけで、
+    アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` の `launchApp` に任せる。
+  - artifact 名は `maestro-results-${{ github.sha }}`（push イベントには PR 番号が無いため）。
+    失敗解析用にビルド済み APK も artifact に含める。
+  - その他（emulator 起動・ANR 対策の `google_atd` イメージ・アニメーション無効化・診断情報採取など）は
+    `e2e.yml` と同じロジックを再利用している。
+- **`warm-devclient-cache`（dev-client APK 温めジョブ）**:
+  - `e2e.yml` が使う dev-client debug APK のビルドキャッシュを main で温める。GitHub Actions のキャッシュは
+    ブランチスコープで、新規 PR ブランチが復元できるのは default ブランチ（main）が書き込んだキャッシュのみ
+    のため、main への push ごとに `e2e.yml` と**同一の fingerprint 計算・同一 profile（`development`）・
+    同一キー（`e2e-android-devclient-apk-x86_64-<hash>`）**で APK を先にキャッシュへ投入する。
+  - fingerprint 計算 → `actions/cache`（ヒットなら温め不要）→ ミス時のみ
+    `eas build --local --profile development` の順。**emulator / Metro / maestro は使わず build のみ**なので
+    release ジョブより軽い。ミス時に build した APK を post ステップの `actions/cache` が default ブランチ
+    スコープへ保存し、以降の PR が復元できる。
 - `concurrency.group` は PR 番号が存在しないため固定文字列 `e2e-main` を使用し、
   `cancel-in-progress: false` として実行中の検証を中断しない（GitHub Actions の concurrency 仕様上、
-  保留は最新 1 件のみ残るためキューが際限なく積み上がることはない）。
-- artifact 名は `maestro-results-${{ github.sha }}`（push イベントには PR 番号が無いため）。
-  失敗解析用にビルド済み APK も artifact に含める。
-- その他（emulator 起動・ANR 対策の `google_atd` イメージ・アニメーション無効化・
-  診断情報採取など）は `e2e.yml` と同じロジックを再利用している。
+  保留は最新 1 件のみ残るためキューが際限なく積み上がることはない）。温めジョブの取りこぼしは次の
+  main push で再温めされるため許容する。
 
 ## iOS を対象に追加する場合
 

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -18,8 +18,10 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
   本来起動時に Metro dev server を探す launcher 画面が出るが、**`defaultLaunchURL` を焼き込んで Metro へ
   自動接続**させることで launcher を経由せず起動する。
 - **config plugin の設定は E2E ビルド時のみ適用する**。`apps/sandbox/app.config.ts`（dynamic config）が
-  `E2E_BUILD=true` のときだけ `expo-dev-client` plugin を追記する。これにより通常の `expo run` や配布用
-  dev build（`eas-build.yml` の `development` プロファイル）の開発体験には影響しない。E2E では次を設定:
+  `E2E_BUILD=true` のときだけ `expo-dev-client` plugin を追記する。E2E は eas.json の `development`
+  プロファイルを再利用するが、通常の development ビルドとの差分は `E2E_BUILD` 環境変数だけ。`E2E_BUILD` を
+  設定しない通常の `expo run` や配布用 dev build（`eas-build.yml` / `eas-build-main.yml` の `development`
+  プロファイル）には plugin が追記されず、開発体験には影響しない。E2E では次を設定:
   - `defaultLaunchURL: "http://localhost:8081"`: launcher を経由せず直接 Metro へ接続。`launchMode`
     （既定 `most-recent`）の fallback としても効くため、`clearState` 後の起動でも再接続する。
   - `skipOnboarding: true` / `showMenuAtLaunch: false` / `toolsButton: false`: オンボーディング・


### PR DESCRIPTION
## 概要

PR ごとの Android E2E(`e2e.yml`)のビルド機構を `expo run:android` + `buildCacheProvider` から `eas build --local`(dev-client debug)+ `@expo/fingerprint` ハッシュをキーにした APK キャッシュへ作り替え、`e2e-main.yml` に main 用の温めジョブを追加した。これにより**ネイティブ変更の無い(JS のみの)PR は初回プッシュからキャッシュヒットしビルドを丸ごとスキップ**できる。

## 背景・動機

新規 PR の初回プッシュで Android ネイティブビルドが重く時間がかかっていた。

原因は **GitHub Actions のキャッシュがブランチスコープ**である点にある。新規 PR ブランチが復元できるのは default ブランチ(main)が書き込んだキャッシュのみだが、従来のネイティブビルドキャッシュ(`buildCacheProvider` / `.expo/build-cache`)は PR の `e2e.yml` しか書き込まず main は書き込まない。そのため新規 PR は初回に一切ヒットせず、毎回フルネイティブビルドになっていた。

さらに `expo run:android` の `buildCacheProvider` はキャッシュ保存(`uploadBuildCache`)が install・launch の**後**にしか走らず、ビルド前に emulator を要求するため「emulator 無しの build だけでキャッシュ投入」ができず、main での温めが困難だった(`@expo/cli` の実コードで確認)。

## アプローチ

`buildCacheProvider` への依存をやめ、ビルド成果物(APK)を自前で fingerprint キャッシュする方式に変更した。

- **ビルド**: `eas build --local --profile development`(既存 `development` プロファイルを再利用。`developmentClient: true` → Android は `:app:assembleDebug` = dev-client debug APK)。emulator 不要でビルドできる。
- **キャッシュキー**: `eas fingerprint:generate --json` の `hash` を exact-match キー `e2e-android-devclient-apk-x86_64-<hash>` に使用。fingerprint はネイティブ依存・config のみが対象(JS は対象外)なので、JS のみの変更ではハッシュ不変 → APK 再利用、更新 JS は Metro(dev-client 接続)が配信する。
- **PR(`e2e.yml`)**: fingerprint 計算 → cache 復元 →(ミス時のみ)`eas build --local` → emulator 起動 → `adb install` → `expo start`(Metro) → `adb reverse` → maestro test。
- **main(`e2e-main.yml`)**: 既存 release e2e ジョブはそのまま。2つ目のジョブ `warm-devclient-cache` を追加し、PR と同一 fingerprint/profile/キーで APK を **build のみ**(emulator/Metro/maestro なし)実行してキャッシュへ事前投入する。

### 検討したが採用しなかった案(案A)

「PR フローは `expo run:android` + `buildCacheProvider` のまま無変更・EXPO_TOKEN 不要を維持し、main の温めジョブだけ emulator を起動して `E2E_BUILD=true expo run:android` を完走させる」案。低リスク・小差分だが、main 温めが emulator 依存で遅く flaky になりやすい。emulator 不要でキャッシュ設計もクリーンな本案を選択した。

### 確認した技術前提

- `eas build --local` は EXPO_TOKEN 必須(プロジェクト存在確認で EAS と通信)。→ **PR CI に EXPO_TOKEN が必要になる**(fork PR 不可。dependabot は既存ガードで除外済み)。
- `@expo/fingerprint` はローカルで決定的、かつシェルの `E2E_BUILD` を反映する(`ExpoConfigLoader` が `process.env` を継承。E2E_BUILD 有無でハッシュが変わることを実測)。→ キャッシュキーは E2E ブロック編集でも正しく無効化される。

## レビューポイント

- **PR CI への EXPO_TOKEN 導入の可否**(現在の「token 不要」を失い、fork PR で e2e が動かせなくなる)。
- **キャッシュの実ヒット**: ローカルでは fingerprint の決定性・E2E_BUILD 反映・両ジョブのコマンド/キー一致まで確認済みだが、**別 runner 間でのキャッシュ実ヒットと dev-client APK の実起動は本 PR の CI 実行が最終検証**になる。初回 PR は main 未温めのため cache MISS(従来どおりの初回ビルド)になり、main マージ後に温めジョブが走って以降の PR から効き始める点に留意。
- `apps/sandbox/eas.json` の `development` プロファイルを E2E に再利用している点(専用プロファイルを増やさずシンプルさ優先。`development` を変更すると e2e のキャッシュ/ビルドが巻き込まれる結合が残る)。

詳細は [`docs/maestro.md`](docs/maestro.md) を参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)