### PR TITLE
test(e2e): E2Eテスト専用ビルド分岐を廃止しMaestroフロー側の接続に統一

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -28,8 +28,10 @@ jobs:
   # eas build --local でビルドし、emulator に install した上で Maestro E2E を実行する。
   # e2e.yml（PRごと、Dev Client + Metro 接続）とはビルド経路（profile / debug vs release）が
   # 根本的に異なるため、ジョブは分ける。
-  # E2E_BUILD は設定しない。設定すると apps/sandbox/app.config.ts が expo-dev-client plugin を
-  # 有効化し、release / 埋め込み JS のビルドに Dev Client が混入するため。
+  # apps/sandbox/app.config.ts の expo-dev-client plugin（skipOnboarding 等）は常時有効だが、
+  # このジョブはそもそも Dev Client を含まない e2e プロファイル（developmentClient: false）で
+  # ビルドするため Dev Client 自体が混入しない。maestro test にも -e DEV_CLIENT を渡さない
+  # （Metro が無いため再接続ステップ自体が不要。apps/sandbox/.maestro/smoke.yaml 参照）。
   # dependabot が @dependabot merge 等で直接 main に push した場合、actor が dependabot[bot]
   # になり secrets.EXPO_TOKEN が渡らず setup-eas が明示エラーで落ちる。main の E2E が
   # 恒常的に失敗してノイズになるのを避けるため、このケースはジョブごと skip する
@@ -100,7 +102,7 @@ jobs:
             --device "pixel_6"
 
       # eas.json の e2e プロファイル（developmentClient: false / release / lintVitalRelease 除外）で
-      # ビルドする。E2E_DEFAULT_LOCALE のみ設定し E2E_BUILD は設定しない（上記コメント参照）。
+      # ビルドする。E2E_DEFAULT_LOCALE のみ設定する（上記コメント参照）。
       - name: Build Android APK (eas build --local, e2e profile)
         env:
           # x86_64 のみビルドして emulator の arch と一致させる（ビルド時間短縮）
@@ -233,7 +235,6 @@ jobs:
         id: fp
         working-directory: apps/sandbox
         env:
-          E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
           HASH="$(pnpm exec fingerprint fingerprint:generate --platform android | jq -r '.hash')"
@@ -260,7 +261,6 @@ jobs:
         working-directory: apps/sandbox
         env:
           ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
-          E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
           eas build --local --profile development --platform android \

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -31,7 +31,7 @@ jobs:
   # apps/sandbox/app.config.ts の expo-dev-client plugin（skipOnboarding 等）は常時有効だが、
   # このジョブはそもそも Dev Client を含まない e2e プロファイル（developmentClient: false）で
   # ビルドするため Dev Client 自体が混入しない。maestro test にも -e DEV_CLIENT を渡さない
-  # （Metro が無いため再接続ステップ自体が不要。apps/sandbox/.maestro/smoke.yaml 参照）。
+  # （Metro が無いため再接続ステップ自体が不要。apps/sandbox/.maestro/subflows/launch-app.yaml 参照）。
   # dependabot が @dependabot merge 等で直接 main に push した場合、actor が dependabot[bot]
   # になり secrets.EXPO_TOKEN が渡らず setup-eas が明示エラーで落ちる。main の E2E が
   # 恒常的に失敗してノイズになるのを避けるため、このケースはジョブごと skip する
@@ -142,9 +142,9 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global animator_duration_scale 0
 
-      # アプリの起動は行わない。apps/sandbox/.maestro/smoke.yaml の先頭が launchApp であり、
-      # maestro test 自体が起動を担う（release / 埋め込み JS のため Metro も不要。install 済みで
-      # あれば launchApp が起動できる）。
+      # アプリの起動は行わない。apps/sandbox/.maestro/smoke.yaml が呼ぶ subflows/launch-app.yaml
+      # （-e DEV_CLIENT 未指定なので素の launchApp 分岐）を maestro test 自体が担う
+      # （release / 埋め込み JS のため Metro も不要。install 済みであれば launchApp が起動できる）。
       - name: Install app
         run: adb install -r apps/sandbox/build-output/sandbox-e2e.apk
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,9 +33,10 @@ jobs:
   # APK を事前にキャッシュへ投入するため、ネイティブ変更の無い（JS のみの）PR は
   # 初回プッシュから default ブランチのキャッシュにヒットし、ビルドを省略できる。
   # app.config.ts は expo-dev-client の config plugin（skipOnboarding 等）を常時有効化する
-  # （E2E ビルド専用の分岐は無い）。clearState 後の Metro への再接続は Maestro フロー側の
-  # ディープリンク（apps/sandbox/.maestro/subflows/connect-metro.yaml、`-e DEV_CLIENT=true`）
-  # で行う。詳細は docs/maestro.md 参照。
+  # （E2E ビルド専用の分岐は無い。preview/production プロファイルにも適用されるが、それらは
+  # Dev Client 自体を含まないビルドのため影響しない）。clearState 後の Metro への再接続は
+  # Maestro フロー側のディープリンク（apps/sandbox/.maestro/subflows/launch-app.yaml、
+  # `-e DEV_CLIENT=true`）で行う。詳細は docs/maestro.md 参照。
   # ビルドは eas build --local を使うため EXPO_TOKEN（secrets）が必要。
   # dev-client debug ビルドには eas.json の development プロファイルを再利用する
   # （developmentClient: true → Android は :app:assembleDebug = APK）。
@@ -208,8 +209,8 @@ jobs:
           # される（ビルドは上の eas build --local 済み）。素の adb install + expo start では dev-client が
           # Metro に接続せず黒画面になるため、接続確立を含む expo run:android の launch ロジックを再利用する。
           # （この初回起動時の接続は expo-cli 自体の機能であり defaultLaunchURL の有無に依存しない。
-          # 後続の Maestro `launchApp: {clearState: true}` による再起動時の再接続は、この初回起動とは
-          # 別に apps/sandbox/.maestro/subflows/connect-metro.yaml のディープリンクで行う）
+          # 後続の Maestro フロー（apps/sandbox/.maestro/subflows/launch-app.yaml）による再起動時の
+          # 再接続は、この初回起動とは別に、独立コマンドの clearState → openLink のディープリンクで行う）
           # Metro はテスト中ずっと生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
           # --binary は絶対パスで渡す（pnpm --dir で cwd が apps/sandbox になり、リポジトリルート相対の
           # $APK_PATH がそのままでは解決できないため $GITHUB_WORKSPACE を前置する）。
@@ -226,8 +227,8 @@ jobs:
           # Metro の readiness を確認
           timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
 
-          # -e DEV_CLIENT=true により、smoke.yaml の launchApp(clearState) 直後にディープリンクで
-          # Metro へ再接続する（apps/sandbox/.maestro/subflows/connect-metro.yaml 参照）。
+          # -e DEV_CLIENT=true により、smoke.yaml が呼ぶ launch-app.yaml が clearState → ディープリンク
+          # （openLink）で Metro へ再接続する（apps/sandbox/.maestro/subflows/launch-app.yaml 参照）。
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
           maestro test -e DEV_CLIENT=true apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,8 +32,10 @@ jobs:
   # main への push では e2e-main.yml の warm ジョブが同じ fingerprint / 同じ profile で
   # APK を事前にキャッシュへ投入するため、ネイティブ変更の無い（JS のみの）PR は
   # 初回プッシュから default ブランチのキャッシュにヒットし、ビルドを省略できる。
-  # E2E_BUILD=true により app.config.ts が expo-dev-client の config plugin を有効化し、
-  # defaultLaunchURL(http://localhost:8081) で launcher を経由せず Metro へ自動接続する。
+  # app.config.ts は expo-dev-client の config plugin（skipOnboarding 等）を常時有効化する
+  # （E2E ビルド専用の分岐は無い）。clearState 後の Metro への再接続は Maestro フロー側の
+  # ディープリンク（apps/sandbox/.maestro/subflows/connect-metro.yaml、`-e DEV_CLIENT=true`）
+  # で行う。詳細は docs/maestro.md 参照。
   # ビルドは eas build --local を使うため EXPO_TOKEN（secrets）が必要。
   # dev-client debug ビルドには eas.json の development プロファイルを再利用する
   # （developmentClient: true → Android は :app:assembleDebug = APK）。
@@ -75,7 +77,7 @@ jobs:
       # eas-cli 経由（eas fingerprint:generate）ではなく @expo/fingerprint の CLI を使う:
       # pnpm-lock.yaml でバージョン固定されるためランをまたいで決定的（eas-version: latest だと
       # 実行時期でアルゴリズムがドリフトしキャッシュが常時 MISS になりうる）で、EAS 認証・ネットワークも
-      # 不要。E2E_BUILD / E2E_DEFAULT_LOCALE は app.config.ts の評価に反映され（ExpoConfigLoader が
+      # 不要。E2E_DEFAULT_LOCALE は app.config.ts の評価に反映され（ExpoConfigLoader が
       # process.env を継承）、.fingerprintignore と eas.json も自動でハッシュ対象に含まれる。
       # fingerprint は JS を含まずネイティブ依存・config のみが対象のため、JS のみの変更ではハッシュ
       # 不変 → 既存 APK を再利用でき、更新 JS は Metro が配信する。PR と e2e-main.yml の warm ジョブは
@@ -84,7 +86,6 @@ jobs:
         id: fp
         working-directory: apps/sandbox
         env:
-          E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
           HASH="$(pnpm exec fingerprint fingerprint:generate --platform android | jq -r '.hash')"
@@ -113,7 +114,6 @@ jobs:
         working-directory: apps/sandbox
         env:
           ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
-          E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
           eas build --local --profile development --platform android \
@@ -174,9 +174,8 @@ jobs:
         env:
           # E2E ビルドはアプリの言語既定値を ja に固定する（emulator ロケールは既定 en-US のまま）。
           # dev-client では Constants.expoConfig は Metro が配信する manifest 由来のため、
-          # expo run:android が起動する Metro にも E2E_BUILD / E2E_DEFAULT_LOCALE を渡して app.config を
+          # expo run:android が起動する Metro にも E2E_DEFAULT_LOCALE を渡して app.config を
           # 同条件で評価させる（i18n/locale.ts の getStoredLocalePreference() のフォールバックが ja になる）。
-          E2E_BUILD: 'true'
           E2E_DEFAULT_LOCALE: ja
         run: |
           # emulator をバックグラウンド起動（テスト端末ロケールは既定の en-US を使う）
@@ -204,10 +203,13 @@ jobs:
           adb shell settings put global animator_duration_scale 0
 
           # ビルド済み（キャッシュ or eas build --local）の dev-client debug APK を expo run:android に
-          # --binary で渡し、install → Metro 起動 → adb reverse → dev-client 起動（defaultLaunchURL で
-          # Metro へ接続）まで一括で行う。--binary で Gradle ビルドはスキップされる（ビルドは上の
-          # eas build --local 済み）。素の adb install + expo start では dev-client が Metro に接続せず
-          # 黒画面になるため、接続確立を含む expo run:android の launch ロジックを再利用する。
+          # --binary で渡し、install → Metro 起動 → adb reverse → dev-client 起動（expo run:android 自身の
+          # launch ロジックが Metro への接続を行う）まで一括で行う。--binary で Gradle ビルドはスキップ
+          # される（ビルドは上の eas build --local 済み）。素の adb install + expo start では dev-client が
+          # Metro に接続せず黒画面になるため、接続確立を含む expo run:android の launch ロジックを再利用する。
+          # （この初回起動時の接続は expo-cli 自体の機能であり defaultLaunchURL の有無に依存しない。
+          # 後続の Maestro `launchApp: {clearState: true}` による再起動時の再接続は、この初回起動とは
+          # 別に apps/sandbox/.maestro/subflows/connect-metro.yaml のディープリンクで行う）
           # Metro はテスト中ずっと生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
           # --binary は絶対パスで渡す（pnpm --dir で cwd が apps/sandbox になり、リポジトリルート相対の
           # $APK_PATH がそのままでは解決できないため $GITHUB_WORKSPACE を前置する）。
@@ -221,11 +223,13 @@ jobs:
               kill -0 '"$EXPO_RUN_PID"' 2>/dev/null || { echo "expo run:android が予期せず終了しました"; exit 1; }
               sleep 5
             done'
-          # Metro の readiness を確認（Dev Client は defaultLaunchURL で localhost:8081 に接続）
+          # Metro の readiness を確認
           timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
 
+          # -e DEV_CLIENT=true により、smoke.yaml の launchApp(clearState) 直後にディープリンクで
+          # Metro へ再接続する（apps/sandbox/.maestro/subflows/connect-metro.yaml 参照）。
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
-          maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
+          maestro test -e DEV_CLIENT=true apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 
       # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
       # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）

--- a/apps/sandbox/.maestro/smoke.yaml
+++ b/apps/sandbox/.maestro/smoke.yaml
@@ -7,21 +7,11 @@
 # 表示テキストは lingui の <Trans>（sourceLocale=ja）。
 appId: com.yamibeta.sandbox
 ---
-- launchApp:
-    clearState: true
+# アプリの起動（Dev Client か release かの分岐を含む）は subflows/launch-app.yaml に
+# 切り出してある。新しいフローを追加する場合もこの1行を最初に置く（docs/maestro.md
+# 「フローの書き方」参照）。分岐の詳細・過去の flaky 対応の経緯は launch-app.yaml のコメントを参照。
+- runFlow: subflows/launch-app.yaml
 # ページの表示確認としてまず画面タイトル「ホーム」を assert し、続けて画面内の項目を確認する。
-# 過去（b0810b4）に、Dev Client ビルド（e2e.yml / PR）で clearState 後 defaultLaunchURL 経由で
-# Metro に再接続する際、「ホーム」が一瞬表示された直後に画面が空白になる現象が観測され、
-# assertVisible の既定リトライ（7秒。docs.maestro.dev/reference/commands-available/assertvisible
-# 参照）では足りず、待機対象を「ナビゲーションパターン」に変更した上でタイムアウトを
-# 40000 → 60000 → 120000 と段階的に伸ばす対応が取られていた
-# （git log --follow -p -- apps/sandbox/.maestro/smoke.yaml 参照）。
-# しかし現在のコードベースでこの空白挙動は再現しない（Dev Client ビルドで clearState ありの
-# 状態から assertVisible のみ・既定リトライで launchApp→3件の assert まで計8回連続成功、
-# 1回あたり約13秒）。そのため extendedWaitUntil による延長は行わず、素の assertVisible に
-# 戻している。将来 Dev Client 側でこの空白挙動由来の flaky failure が再発した場合は、
-# テストのタイムアウトを伸ばす前に、まず実装側（Metro 再接続・router hydration 等）の
-# 遅延の原因を調査すること。
 - assertVisible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
 - assertVisible: "ナビゲーションパターン" # GroupedList の先頭項目
 - assertVisible: "コンポーネント"

--- a/apps/sandbox/.maestro/subflows/launch-app.yaml
+++ b/apps/sandbox/.maestro/subflows/launch-app.yaml
@@ -1,0 +1,32 @@
+# アプリの起動をビルド種別で分岐する共通サブフロー。各テストフローは
+# `runFlow: subflows/launch-app.yaml` の1行を最初に置くだけでよい
+# （分岐ロジック自体をテストフローごとに書かない。docs/maestro.md「フローの書き方」参照）。
+# maestro test はデフォルトでサブフォルダを走査しないため、このファイルも runFlow から
+# 明示的に呼ばれない限り単独のテストとしては実行されない。
+appId: com.yamibeta.sandbox
+---
+# Dev Client ビルド（-e DEV_CLIENT=true）は、クリーンな状態から launcher 画面を経由せず
+# ディープリンクで直接 Metro（http://localhost:8081）へ接続する。従来 app.config.ts の
+# defaultLaunchURL がビルド時に焼き込んでいた効果を、ランタイムのディープリンクで実現する
+# （expo-dev-launcher は <scheme>://expo-development-client/?url=<encoded> 形式の VIEW
+# インテントを isDevLauncherUrl で検出し、指定 URL の Metro へ接続する）。
+#
+# clearState（独立コマンド。アプリを起動しない）→ openLink（未起動の状態から直接コールドスタート）
+# の順にする。launchApp で一度「未接続の launcher 状態」でアプリを起動してから別ステップで
+# openLink すると、redirect 分の遅延で assertVisible の既定リトライ（7秒）ではタイムアウトする
+# ことを実機検証（Pixel_9_Pro_API_35 emulator）で確認している。この順序なら素の assertVisible
+# のみで安定する（詳細は docs/maestro.md「フローの書き方」参照）。
+- runFlow:
+    when:
+      true: ${DEV_CLIENT == "true"}
+    commands:
+      - clearState
+      - openLink: "exp+sandbox://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+    label: "Dev Client ビルドの場合はディープリンクで直接起動する（-e DEV_CLIENT=true のときのみ）"
+- runFlow:
+    when:
+      true: ${DEV_CLIENT != "true"}
+    commands:
+      - launchApp:
+          clearState: true
+    label: "Dev Client を使わない場合（release / 埋め込み JS）は通常どおり起動する"

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -1,40 +1,25 @@
 import type { ConfigContext, ExpoConfig } from "expo/config";
 
-// app.json を base に読み込み、E2E ビルド時（E2E_BUILD=true）だけ expo-dev-client の
-// config plugin を追記する dynamic config。通常の expo run / 配布用 dev build
-// （eas.json の development プロファイル）には影響しない。
+// app.json を base に読み込む dynamic config。
 //
-// E2E では Dev Client を Metro に自動接続させ、テストを阻害するオーバーレイを抑止する:
-// - defaultLaunchURL: launcher を経由せず直接 Metro へ接続（launchMode=most-recent の
-//   fallback としても効くため clearState 後も再接続する）
+// expo-dev-client の launch 時オンボーディング・起動時デベロッパーメニュー・フローティング
+// ツールボタンは Maestro E2E の assert を阻害するため常時無効化する（E2E ビルド専用の分岐は
+// 設けず、通常の expo run / 配布用 dev build を含むすべての Dev Client ビルドに適用する）:
 // - skipOnboarding / showMenuAtLaunch / toolsButton: オンボーディング・起動時メニュー・
 //   フローティングツールボタンが assert を阻害しないよう無効化する
 //
-// E2E の CI では dev-client debug APK を eas build --local でビルドし、@expo/fingerprint の
-// ハッシュをキーに APK を actions/cache へ保存して再利用する（buildCacheProvider には依存しない）。
-// 詳細は docs/maestro.md を参照。
+// Metro への接続（従来 defaultLaunchURL で焼き込んでいたもの）はビルド設定ではなく、
+// Maestro フロー側のディープリンク（apps/sandbox/.maestro/subflows/connect-metro.yaml）で
+// 行う。詳細は docs/maestro.md を参照。
 export default ({ config }: ConfigContext): ExpoConfig => {
-  const plugins = [...(config.plugins ?? [])];
-  const isE2EBuild = process.env.E2E_BUILD === "true";
-
-  if (isE2EBuild) {
-    const devClientPlugin: [string, Record<string, unknown>] = [
-      "expo-dev-client",
-      {
-        skipOnboarding: true,
-        showMenuAtLaunch: false,
-        toolsButton: false,
-        defaultLaunchURL: "http://localhost:8081",
-      },
-    ];
-    plugins.push(devClientPlugin);
-  }
-
   return {
     ...config,
     name: config.name ?? "sandbox",
     slug: config.slug ?? "sandbox",
-    plugins,
+    plugins: [
+      ...(config.plugins ?? []),
+      ["expo-dev-client", { skipOnboarding: true, showMenuAtLaunch: false, toolsButton: false }],
+    ],
     extra: {
       ...config.extra,
       // E2E ビルドでアプリの表示言語を固定するための既定値（src/i18n/locale.ts が参照）。

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -7,9 +7,12 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 // 設けず、通常の expo run / 配布用 dev build を含むすべての Dev Client ビルドに適用する）:
 // - skipOnboarding / showMenuAtLaunch / toolsButton: オンボーディング・起動時メニュー・
 //   フローティングツールボタンが assert を阻害しないよう無効化する
+// この plugin エントリ自体は eas.json の全プロファイル（preview/production 含む）で評価されるが、
+// developmentClient を有効にしないビルド（e2e/preview/production）は Dev Client のネイティブ
+// コード自体を含まないため、上記オプションは実質的に無関係で影響しない。
 //
 // Metro への接続（従来 defaultLaunchURL で焼き込んでいたもの）はビルド設定ではなく、
-// Maestro フロー側のディープリンク（apps/sandbox/.maestro/subflows/connect-metro.yaml）で
+// Maestro フロー側のディープリンク（apps/sandbox/.maestro/subflows/launch-app.yaml）で
 // 行う。詳細は docs/maestro.md を参照。
 export default ({ config }: ConfigContext): ExpoConfig => {
   return {

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -15,25 +15,35 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
   ではなく debug ビルドにすることでビルド時間も短縮する。dev-client debug ビルドには eas.json の
   `development` プロファイル（`developmentClient: true` → Android は `:app:assembleDebug` = APK）を再利用し、
   CI では `eas build --local --profile development` でビルドする。Dev Client（`developmentClient: true`）は
-  本来起動時に Metro dev server を探す launcher 画面が出るが、**`defaultLaunchURL` を焼き込んで Metro へ
-  自動接続**させることで launcher を経由せず起動する。
-- **config plugin の設定は E2E ビルド時のみ適用する**。`apps/sandbox/app.config.ts`（dynamic config）が
-  `E2E_BUILD=true` のときだけ `expo-dev-client` plugin を追記する。E2E は eas.json の `development`
-  プロファイルを再利用するが、通常の development ビルドとの差分は `E2E_BUILD` 環境変数だけ。`E2E_BUILD` を
-  設定しない通常の `expo run` や配布用 dev build（`eas-build.yml` / `eas-build-main.yml` の `development`
-  プロファイル）には plugin が追記されず、開発体験には影響しない。E2E では次を設定:
-  - `defaultLaunchURL: "http://localhost:8081"`: launcher を経由せず直接 Metro へ接続。`launchMode`
-    （既定 `most-recent`）の fallback としても効くため、`clearState` 後の起動でも再接続する。
+  本来起動時に Metro dev server を探す launcher 画面が出るが、Maestro フロー側でディープリンクを送り
+  **launcher を経由せず Metro へ再接続**させる（後述）。
+- **expo-dev-client の config plugin は常時適用する（E2E ビルド専用の分岐は無い）**。
+  `apps/sandbox/app.config.ts`（dynamic config）が Dev Client を含むすべてのビルド
+  （通常の `expo run` / 配布用 dev build / CI の E2E ビルド）に対して次を常時設定する:
   - `skipOnboarding: true` / `showMenuAtLaunch: false` / `toolsButton: false`: オンボーディング・
     起動時のデベロッパーメニュー・フローティングツールボタンが assert を阻害しないよう無効化する。
-- **フローは Dev Client あり/なしの両対応**。`defaultLaunchURL` による自動接続のおかげで、Maestro フローは
-  単一の `launchApp` で済み、Dev Client あり（自動接続）/ なし（埋め込み JS）の両方が同じフローで通る。
-  Dev Client を含まない E2E（`e2e` プロファイル / release / 埋め込み JS）は `.github/workflows/e2e-main.yml`
-  で main ブランチへの push 時に実行し、同じフローを再利用する。
+    これらは以前 `E2E_BUILD=true` のときだけ有効化していたが、`expo-dev-menu` は
+    `showMenuAtLaunch`/`skipOnboarding` の既定値がいずれも「表示する」側（OR 条件でどちらか一方でも
+    満たせばメニューが自動表示される）で、`clearState` 後は毎回この既定値に戻ってしまうため、
+    E2E ビルドだけに閉じずすべてのビルドで常時無効化することにした（CI が経験したことのない
+    「メニュー自動表示」を新たに持ち込むリスクを避けるため）。
+  - Metro への接続（以前は `defaultLaunchURL` をビルド時に焼き込んでいた）は config plugin ではなく
+    **Maestro フロー側のディープリンク**で行う。`expo-dev-launcher` は
+    `<scheme>://expo-development-client/?url=<encoded>` 形式の VIEW インテントを受け取ると、
+    ビルド時の設定に関わらずそのURLのMetroへ接続する。この仕組みは起動方法を分岐する共通サブフロー
+    `apps/sandbox/.maestro/subflows/launch-app.yaml` に閉じており、Dev Client ビルドのときだけ
+    （`-e DEV_CLIENT=true`）実行される（「フローの書き方」参照）。
+- **フローは Dev Client あり/なしの両対応**。各テストフローは起動処理を自前で書かず
+  `runFlow: subflows/launch-app.yaml` の1行を呼ぶだけで、`-e DEV_CLIENT` を渡すかどうかだけで
+  両方のビルド種別に対応する（「フローの書き方」参照）。
+  Dev Client を含まない E2E（`e2e` プロファイル / release / 埋め込み JS）は
+  `.github/workflows/e2e-main.yml` で main ブランチへの push 時に実行し、同じフローを再利用する。
 - **release ビルドの lint を除外**（非 Dev Client 用 `e2e` プロファイル）。`developmentClient: false`
   は release variant でビルドされ、`lintVitalRelease`（lint）が CI ランナーのメモリを使い切って
   `OutOfMemoryError` で落ちる。lint は E2E ビルドに不要（品質チェックは oxlint / expo lint で別途実施）なため、
   `e2e` プロファイルの `android.gradleCommand` を `:app:assembleRelease -x lintVitalRelease` にして除外している。
+  なお `developmentClient: false` は release variant のビルドであり、`expo-dev-launcher` 等の
+  Dev Client 専用ネイティブコードは（config plugin の設定に関わらず）そもそも含まれない。
 - **ネイティブ部分に変更が無ければビルドをスキップする**。dev-client debug APK を
   `eas build --local --profile development` でビルドし、`@expo/fingerprint` のハッシュ（依存関係・
   ネイティブコード・config plugin・app.json/app.config の設定が対象。JS/TSX のアプリケーションソースは
@@ -53,29 +63,72 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
 
 | ファイル | 役割 |
 | --- | --- |
-| `apps/sandbox/app.config.ts` | dynamic config。`E2E_BUILD=true` のときだけ `expo-dev-client` plugin（`defaultLaunchURL` 等）を追記。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す。通常ビルドはどちらも未設定 |
+| `apps/sandbox/app.config.ts` | dynamic config。`expo-dev-client` plugin（`skipOnboarding` / `showMenuAtLaunch` / `toolsButton`）を常時追記する。`E2E_DEFAULT_LOCALE` を `extra.e2eDefaultLocale` に埋め込み `src/i18n/locale.ts` の既定言語フォールバックへ渡す（こちらは通常ビルドでは未設定） |
 | `apps/sandbox/.fingerprintignore` | dev-client APK キャッシュのキーに使う `@expo/fingerprint` の計算から除外するパス。ビルドで内容が変わり無駄な MISS を招く既知のファイル（`@react-native-masked-view/masked-view` の `AndroidManifest.xml` 等）を列挙 |
 | `apps/sandbox/eas.json` の `development` プロファイル | PR の dev-client debug E2E ビルドに再利用（`developmentClient: true` → Android は `:app:assembleDebug` = APK） |
 | `apps/sandbox/eas.json` の `e2e` プロファイル | 非 Dev Client 用（main の release E2E）ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
-| `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（単一 `launchApp`） |
-| `.github/workflows/e2e.yml` | PR ごとに「fingerprint 計算 → APK キャッシュ復元／（ミス時）`eas build --local --profile development` → emulator 起動 → `expo run:android --binary <APK>`（install→Metro→`adb reverse`→dev-client 起動）→ maestro test」を実行 |
-| `.github/workflows/e2e-main.yml` | main への push ごとに、release E2E ジョブ（`eas build --local --profile e2e` → install → maestro）と dev-client APK 温めジョブ（`warm-devclient-cache`。fingerprint → `eas build --local --profile development` → キャッシュ保存。build のみ）を並列実行 |
+| `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（起動処理は `runFlow: subflows/launch-app.yaml` の1行に任せる。「フローの書き方」参照） |
+| `apps/sandbox/.maestro/subflows/launch-app.yaml` | 起動方法をビルド種別で分岐する共通サブフロー。`DEV_CLIENT` に応じて `clearState` → ディープリンク（`openLink`）による Metro 接続を行うか、素の `launchApp: {clearState: true}` を実行するかを切り替える。各テストフローはこれを `runFlow` で呼ぶだけでよく、分岐ロジックを重複して書かない。`maestro test` はデフォルトでサブフォルダを走査しないため単独実行はされない |
+| `.github/workflows/e2e.yml` | PR ごとに「fingerprint 計算 → APK キャッシュ復元／（ミス時）`eas build --local --profile development` → emulator 起動 → `expo run:android --binary <APK>`（install→Metro→`adb reverse`→dev-client 起動）→ `maestro test -e DEV_CLIENT=true`」を実行 |
+| `.github/workflows/e2e-main.yml` | main への push ごとに、release E2E ジョブ（`eas build --local --profile e2e` → install → `maestro test`。Dev Client が無いため `-e DEV_CLIENT` は渡さない）と dev-client APK 温めジョブ（`warm-devclient-cache`。fingerprint → `eas build --local --profile development` → キャッシュ保存。build のみ）を並列実行 |
 
 ## フローの書き方
 
-`apps/sandbox/.maestro/` に `*.yaml` を追加する（機能ごとに co-location）。
+`apps/sandbox/.maestro/` に `*.yaml` を追加する（機能ごとに co-location）。アプリの起動処理は
+自前で書かず、共通サブフロー `runFlow: subflows/launch-app.yaml` を最初に置くだけでよい:
 
 ```yaml
 appId: com.yamibeta.sandbox
 ---
-- launchApp:
-    clearState: true
+- runFlow: subflows/launch-app.yaml
 - assertVisible: "ホーム"
 ```
 
-Dev Client（E2E ビルド）では `defaultLaunchURL` により `launchApp` だけで Metro へ自動接続するため、
-`openLink` や Dev Client 専用の分岐は不要。同じフローが非 Dev Client ビルドでもそのまま動く。
-launcher 操作などビルド種別に依存する手順をフローに書かないこと（dual-mode を壊さないため）。
+`launch-app.yaml`（`apps/sandbox/.maestro/subflows/launch-app.yaml`）が `DEV_CLIENT` で
+起動方法を分岐する:
+
+```yaml
+appId: com.yamibeta.sandbox
+---
+- runFlow:
+    when:
+      true: ${DEV_CLIENT == "true"}
+    commands:
+      - clearState
+      - openLink: "exp+sandbox://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+    label: "Dev Client ビルドの場合はディープリンクで直接起動する（-e DEV_CLIENT=true のときのみ）"
+- runFlow:
+    when:
+      true: ${DEV_CLIENT != "true"}
+    commands:
+      - launchApp:
+          clearState: true
+    label: "Dev Client を使わない場合（release / 埋め込み JS）は通常どおり起動する"
+```
+
+`-e DEV_CLIENT=true` を渡すと、`clearState`（独立コマンド。アプリを起動せず `pm clear` のみ）→
+`openLink`（未起動の状態からディープリンクで直接コールドスタート）が実行され、Metro に接続した
+状態でアプリが立ち上がる（`expo-dev-launcher` は `<scheme>://expo-development-client/?url=<encoded>`
+形式の VIEW インテントを `isDevLauncherUrl` で検出し、指定 URL の Metro へ接続する。従来
+`app.config.ts` の `defaultLaunchURL` がビルド時に焼き込んでいた効果をランタイムのディープリンクで
+実現している）。渡さない場合（release / 埋め込み JS ビルド、あるいは Dev Client を使わずローカルで
+動作確認する場合）は2つ目の `runFlow` が実行され、通常の `launchApp: {clearState: true}` で起動する。
+`-e DEV_CLIENT` を渡すかどうかの分岐は `launch-app.yaml` の1ファイルに閉じており、CLI パラメータ
+（`-e`）は `runFlow` のネスト（`smoke.yaml` → `launch-app.yaml`）をまたいでも自動的に引き継がれる
+ため、各テストフロー側で `${DEV_CLIENT}` を意識する必要はない。`openLink` や Dev Client 専用の
+分岐をテストフロー側や `launch-app.yaml` の2つの `runFlow` 以外に増やさないこと（フローの見た目上は
+ビルド種別に依存する手順が無い状態を保ち、dual-mode を壊さないため）。
+
+**`launchApp: {clearState: true}` の直後に別ステップで `openLink`（または `runFlow` 経由の
+ディープリンク）を送る構成にしないこと。** 過去（b0810b4）に `launchApp(clearState)` →
+`defaultLaunchURL` 経由の再接続という順序で、「ホーム」が一瞬表示された直後に空白になる flaky が
+観測されていた。`defaultLaunchURL` をディープリンクに置き換える際、同じ「`launchApp` で一度
+未接続の launcher 状態を作ってから別ステップで接続し直す」構成を試したところ、実機検証
+（Pixel_9_Pro_API_35 emulator）で同様の遅延（素の `assertVisible` の既定7秒リトライでは
+タイムアウトし、実際には十数秒後に表示される）が再発した。上記のように
+`clearState`（独立コマンド）→ `openLink` による直接コールドスタートという構成に変更したところ、
+同じ実機検証で素の `assertVisible` のみ・3回連続成功した（1回あたり15〜24秒）ため、
+`extendedWaitUntil` によるタイムアウト延長は行わない。
 
 ### ロケールに関する注意
 
@@ -106,18 +159,18 @@ assert（`ホーム` / `ナビゲーションパターン` / `コンポーネン
 アプリ言語は `E2E_DEFAULT_LOCALE=ja` で固定する）** が必要。
 Maestro CLI が未インストールなら `curl -fsSL "https://get.maestro.mobile.dev" | bash`。
 
-### Dev Client 経路（推奨・ローカル開発と同一）
+### Dev Client 経路（推奨・ローカル開発と同一ビルドをそのまま使う）
 
-`E2E_BUILD=true` を付けて `expo run:android` すると、`app.config.ts` が E2E 用 config plugin を
-有効化した Development Build をビルドし、Metro 起動・install・`adb reverse`・接続まで自動で行う。
+`expo-dev-client` の config plugin は常時適用されるため、E2E 専用のビルドは無い。普段の開発で
+使っている Dev Client ビルド（`pnpm --dir apps/sandbox android` あるいは既にインストール済みなら
+`pnpm --dir apps/sandbox start`）をそのまま使い、Maestro 実行時にだけ `-e DEV_CLIENT=true` を渡す。
 
 ```bash
-# 1. E2E 設定の Development Build をビルド・install・Metro 起動（連続稼働）
-#    E2E_DEFAULT_LOCALE=ja でアプリの言語既定値を ja に固定する
-E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec expo run:android
+# 1. 普段どおり Dev Client ビルドを用意する（インストール済みなら Metro 起動だけでよい）
+pnpm --dir apps/sandbox exec expo run:android
 
-# 2. 別ターミナルでフローを実行（Dev Client は defaultLaunchURL で Metro に自動接続）
-maestro test apps/sandbox/.maestro/
+# 2. 別ターミナルでフローを実行する（-e DEV_CLIENT=true でディープリンクによる Metro 再接続が有効になる）
+maestro test -e DEV_CLIENT=true apps/sandbox/.maestro/
 ```
 
 > CI（`e2e.yml`）は同じ dev-client debug ビルドを `eas build --local --profile development` で作り
@@ -125,16 +178,7 @@ maestro test apps/sandbox/.maestro/
 > `expo run:android --binary <APK>` に渡して install→Metro→`adb reverse`→dev-client 起動まで行う
 > （`--binary` で Gradle ビルドはスキップ。素の `adb install` + `expo start` では dev-client が Metro に
 > 接続せず黒画面になるため、接続確立を含む run:android の launch ロジックを使う）。CI と同じ経路を手元で
-> 再現したい場合は、上の Dev Client 経路（`expo run:android`）をそのまま使えばよい。APK を明示的に作るなら:
->
-> ```bash
-> E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec eas build --local \
->   --profile development --platform android --non-interactive \
->   --output ./build-output/sandbox-e2e-devclient.apk
-> # 上記 APK を使って install→Metro→起動:
-> E2E_BUILD=true E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec \
->   expo run:android --binary ./build-output/sandbox-e2e-devclient.apk
-> ```
+> 再現したい場合は、上の Dev Client 経路（`expo run:android`）をそのまま使えばよい。
 
 ### 非 Dev Client 経路（main 互換の回帰確認）
 
@@ -152,7 +196,7 @@ E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec eas build --local --profile e
 # 2. 起動済みの emulator に install（emulator が無ければ別途 `emulator -avd <name>` で起動）
 adb install -r apps/sandbox/build-output/sandbox-e2e.apk
 
-# 3. 同じフローを実行（Metro 不要）
+# 3. 同じフローを実行（Metro 不要、-e DEV_CLIENT は渡さない）
 maestro test apps/sandbox/.maestro/
 ```
 
@@ -167,14 +211,17 @@ maestro test apps/sandbox/.maestro/
   `actions/cache`（キー `e2e-android-devclient-apk-x86_64-<hash>`）→ ミス時のみ
   `eas build --local --profile development`（dev-client debug APK）→ emulator 起動 →
   `expo run:android --binary <APK>`（install→Metro 起動→`adb reverse`→dev-client 起動を一括。`--binary` で
-  Gradle ビルドはスキップ）→ アプリ起動（MainActivity）と Metro readiness を待って `maestro test`。
-  テスト後は `expo run:android`（Metro 含む）を kill する。
-- **`adb install` + `expo start` の手組みは使わない**。dev-client は素の `launchApp` では `defaultLaunchURL`
-  の自動接続が効かず黒画面になる（Metro に bundle を要求しない）ため、接続確立を含む `expo run:android` の
-  launch ロジック（`--binary` でビルドのみスキップ）を再利用する。dev-client 起動後の Metro 接続確立は
-  run:android が担い、maestro の `launchApp`（clearState）はその接続を再利用する。
-- `E2E_BUILD` / `E2E_DEFAULT_LOCALE` は fingerprint 計算・ビルド・`expo run:android` の各ステップに
-  step `env` として同じ値（`true` / `ja`）を渡す。dev-client では `Constants.expoConfig` が Metro 配信の
+  Gradle ビルドはスキップ）→ アプリ起動（MainActivity）と Metro readiness を待って
+  `maestro test -e DEV_CLIENT=true`（`clearState` 後にディープリンクで直接コールドスタートし
+  Metro へ接続する）。テスト後は `expo run:android`（Metro 含む）を kill する。
+- **`adb install` + `expo start` の手組みは使わない**。dev-client の初回起動（`expo run:android` が
+  自身で行う Metro 接続）は run:android 自体の launch ロジックに任せる必要があり（素の `adb install` +
+  `expo start` では Metro に接続せず黒画面になる）、`--binary` で Gradle ビルドのみスキップして
+  このロジックを再利用する。dev-client 起動後の Metro 接続確立は run:android が担い、maestro の
+  `clearState` で状態がクリアされた後の再接続は `-e DEV_CLIENT=true` によるディープリンク
+  （`apps/sandbox/.maestro/subflows/launch-app.yaml`）が担う。
+- `E2E_DEFAULT_LOCALE` は fingerprint 計算・ビルド・`expo run:android` の各ステップに
+  step `env` として同じ値（`ja`）を渡す。dev-client では `Constants.expoConfig` が Metro 配信の
   manifest 由来のため、run:android が起動する Metro にも渡して app.config を同条件で評価させる（既定言語が `ja`）。
 - アプリの言語は `E2E_DEFAULT_LOCALE=ja` で固定するため、adb によるロケール固定は行わない
   （emulator ロケールは既定 en-US のまま）。
@@ -206,8 +253,11 @@ maestro test apps/sandbox/.maestro/
 - **2 つのジョブを並列実行する**。目的が異なる（release 検証 vs dev-client キャッシュ温め）ため独立させる。
 - **`e2e-android`（release E2E ジョブ）**:
   - ビルドは `eas build --local --profile e2e --platform android`（本番相当の release ビルド・
-    Dev Client 無し・埋め込み JS）で行う。`E2E_BUILD` は設定しない（`E2E_DEFAULT_LOCALE=ja` のみ設定）。
-    設定すると `app.config.ts` が `expo-dev-client` plugin を有効化して Dev Client が混入するため。
+    Dev Client 無し・埋め込み JS）で行う。`E2E_DEFAULT_LOCALE=ja` のみ設定する。
+    `app.config.ts` の `expo-dev-client` plugin は常時有効だが、`e2e` プロファイル
+    （`developmentClient: false`）は release variant でビルドするため Dev Client の
+    ネイティブコード自体が含まれず影響しない。`maestro test` にも `-e DEV_CLIENT` を渡さない
+    （Metro が無いため再接続ステップが不要。渡さなければ `runFlow` がスキップされるだけで安全）。
     EAS の認証には `.github/actions/setup-eas`（`secrets.EXPO_TOKEN`）を使う。
   - Metro は使わないため、build→install→起動の自動化は無い。ビルドした APK を `adb install` するだけで、
     アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` の `launchApp` に任せる。
@@ -231,9 +281,11 @@ maestro test apps/sandbox/.maestro/
 
 ## iOS を対象に追加する場合
 
-- Dev Client なら macOS ランナーで `E2E_BUILD=true expo run:ios`（simulator）を使う。非 Dev Client なら
-  `e2e` プロファイル（`ios.simulator: true`）を `eas build --local --platform ios` でビルドする。
+- Dev Client なら macOS ランナーで `expo run:ios`（simulator）を使い、Maestro 実行時に
+  `-e DEV_CLIENT=true` を渡す。非 Dev Client なら `e2e` プロファイル（`ios.simulator: true`）を
+  `eas build --local --platform ios` でビルドする。
 - ワークフローに macOS ランナーの `e2e-ios` ジョブを追加し、simulator を起動 → 上記でビルド/install →
   `maestro test` を実行する。フロー（`.maestro/*.yaml`）はそのまま再利用できる。
 - iOS simulator は `localhost` が直接ホストを指すため `adb reverse` は不要（`expo run:ios` 経由なら
-  Metro 接続も自動）。`defaultLaunchURL: http://localhost:8081` のまま Metro に接続できる。
+  Metro 接続も自動）。`apps/sandbox/.maestro/subflows/launch-app.yaml` のディープリンクも
+  `http://localhost:8081` のまま Metro に接続できる。

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -18,8 +18,9 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
   本来起動時に Metro dev server を探す launcher 画面が出るが、Maestro フロー側でディープリンクを送り
   **launcher を経由せず Metro へ再接続**させる（後述）。
 - **expo-dev-client の config plugin は常時適用する（E2E ビルド専用の分岐は無い）**。
-  `apps/sandbox/app.config.ts`（dynamic config）が Dev Client を含むすべてのビルド
-  （通常の `expo run` / 配布用 dev build / CI の E2E ビルド）に対して次を常時設定する:
+  `apps/sandbox/app.config.ts`（dynamic config）の plugin エントリ自体は `eas.json` の全プロファイル
+  （`preview`/`production` 含む）で評価されるが、実際に効くのは Dev Client を含むビルド
+  （通常の `expo run` / 配布用 dev build / CI の E2E ビルド）のみで、次を常時設定する:
   - `skipOnboarding: true` / `showMenuAtLaunch: false` / `toolsButton: false`: オンボーディング・
     起動時のデベロッパーメニュー・フローティングツールボタンが assert を阻害しないよう無効化する。
     これらは以前 `E2E_BUILD=true` のときだけ有効化していたが、`expo-dev-menu` は
@@ -260,7 +261,8 @@ maestro test apps/sandbox/.maestro/
     （Metro が無いため再接続ステップが不要。渡さなければ `runFlow` がスキップされるだけで安全）。
     EAS の認証には `.github/actions/setup-eas`（`secrets.EXPO_TOKEN`）を使う。
   - Metro は使わないため、build→install→起動の自動化は無い。ビルドした APK を `adb install` するだけで、
-    アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` の `launchApp` に任せる。
+    アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` が呼ぶ `subflows/launch-app.yaml`
+    （`-e DEV_CLIENT` 未指定なので素の `launchApp` 分岐）に任せる。
   - artifact 名は `maestro-results-${{ github.sha }}`（push イベントには PR 番号が無いため）。
     失敗解析用にビルド済み APK も artifact に含める。
   - その他（emulator 起動・ANR 対策の `google_atd` イメージ・アニメーション無効化・診断情報採取など）は


### PR DESCRIPTION
## 概要

`E2E_BUILD` 環境変数による `app.config.ts` のビルド分岐（`isE2EBuild`）を廃止し、`expo-dev-client` の config plugin（`skipOnboarding`/`showMenuAtLaunch`/`toolsButton`）をすべての Dev Client ビルドに常時適用する。CI・ローカル開発・配布用 dev build を問わず同一のビルド設定になり、「E2E専用ビルド」という概念自体を無くす。

## 背景・動機

- ローカルで E2E を素早く試したい（そのたびに再ビルドが発生する手間を減らしたい）という要望から検討を始めた。
- 当初は `defaultLaunchURL` 等の E2E専用設定を常時オンにする案を検討したが、通常開発時に任意の Metro サーバーへ接続する自由度を失う点、`clearState` 後の再接続タイミングによる画面ちらつきの既知の flaky（`b0810b4`）を抱え込む点から見送った。
- 議論の中で、本来の目的は「ローカルでの再ビルドを避ける」ことではなく「E2E専用ビルドという分岐自体を無くすこと」だと判明し、方針を転換した。

## アプローチ

- `defaultLaunchURL`（launcher画面を経由せずMetroへ自動接続する効果）は、Maestro フロー側のディープリンクで代替する。`expo-dev-launcher` は `<scheme>://expo-development-client/?url=<encoded>` 形式の VIEW インテントを受け取ると、ビルド時の設定に関わらず接続する（`DevLauncherController.kt` の `isDevLauncherUrl` で実装を確認済み）。
- `skipOnboarding`/`showMenuAtLaunch`/`toolsButton` は、当初 Maestro 側で条件付き dismiss する案も検討したが、`expo-dev-menu` の既定値が OR 条件で「表示する」側であるため、CI が経験したことのない「メニュー自動表示」という新規リスクを持ち込む。レビュー相談の結果、これらは E2E専用に閉じず常時適用に変更し、CI の挙動を変えない安全側の選択とした。
- 新規 `apps/sandbox/.maestro/subflows/launch-app.yaml` が `DEV_CLIENT` の値で起動方法を分岐する共通サブフロー。Dev Client の場合は `clearState`（独立コマンド）→ `openLink`（ディープリンクで未起動状態から直接コールドスタート）、それ以外は素の `launchApp`。実機検証（Pixel_9_Pro_API_35 emulator）で、`launchApp(clearState)` の直後に別ステップで `openLink` する構成だと過去と同種の再接続 flaky が再発することを確認し、`clearState` 単体 → `openLink` で直接コールドスタートする順序に変更した。これにより `extendedWaitUntil` によるタイムアウト延長は不要。
- `apps/sandbox/.maestro/smoke.yaml` は起動処理を `runFlow: subflows/launch-app.yaml` に委譲し、各テストフローで分岐ロジックを重複させない構成にした。

## レビューポイント

- `/code-review`（xhigh effort）で見つかった、実装と食い違うコメント記述（削除済みファイル `connect-metro.yaml` への参照、`launchApp(clearState)` 直後にディープリンクという誤った再接続メカニズムの説明など）を2つ目のコミットで修正済み。
- `expo-dev-client` の config plugin 常時適用は、`eas.json` の `preview`/`production` プロファイルにも適用範囲が及ぶ（`developmentClient` を有効にしないため実際には無関係だが、意図した通りの副作用か確認いただけると幸い）。
- ローカルで `-e DEV_CLIENT` を渡さない場合、Maestro の GraalJS エンジンは未定義変数を `ReferenceError` にせず安全に `undefined` として評価するため、`e2e-main.yml` の release ジョブ（`-e DEV_CLIENT` 未指定）は問題なく動作する（実機検証・複数の独立レビューで確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)