### PR TITLE
feat(redirect): Expo Router の Redirect サンプルを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ monorepo で管理された Expo アプリケーションのリポジトリ
 - `docs/`: 長期的に参照する設計ドキュメント・運用手順
 - `tasks/`: 後続タスクの引き継ぎ資料・バックログ。完了後は削除/アーカイブ
 
+### コードスタイル
+
+- **JSX の条件分岐**: DRY を優先して条件分岐が複数箇所に散らばると、読解時に複数条件を頭の中で合成する必要が生じ、コンテキスト消費が増える。多少の重複を許容してでも1つの状態の挙動を1箇所で追える方を優先する
+  - 具体的なテクニック・コード例は [`docs/conditional-rendering.md`](docs/conditional-rendering.md)
+
 ## Commands
 
 `apps/sandbox/package.json` を参照

--- a/apps/sandbox/src/__tests__/redirect.test.tsx
+++ b/apps/sandbox/src/__tests__/redirect.test.tsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { fireEvent, screen, waitFor } from "@testing-library/react-native";
+import type { ReactNode } from "react";
+import RedirectCompleteScreen from "../app/(tabs)/(home)/redirect/complete";
+import RedirectDemo from "../app/(tabs)/(home)/redirect/index";
+import { renderWithProviders } from "../test-utils/render";
+
+const mockRedirect = jest.fn();
+
+// Stack.Screen.Title は実際のナビゲーションコンテキストを要求するため、
+// 画面遷移(Redirect)の検証に不要な部分ごとモックする。
+jest.mock("expo-router", () => ({
+  Redirect: (props: { href: string }) => {
+    mockRedirect(props);
+    return null;
+  },
+  Stack: {
+    Screen: {
+      Title: (_props: { children?: ReactNode }) => null,
+    },
+  },
+}));
+
+describe("redirect サンプル (index)", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("初期表示では送信ボタンを表示し、Redirect は呼ばれない", async () => {
+    await renderWithProviders(<RedirectDemo />);
+
+    expect(screen.getByText("送信する")).toBeOnTheScreen();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("送信すると送信中の表示に切り替わり、完了後に /redirect/complete への Redirect が呼ばれる", async () => {
+    await renderWithProviders(<RedirectDemo />);
+
+    await fireEvent.press(screen.getByText("送信する"));
+
+    expect(screen.getByText("送信中…")).toBeOnTheScreen();
+
+    await waitFor(
+      () => {
+        expect(mockRedirect).toHaveBeenCalledWith(
+          expect.objectContaining({ href: "/redirect/complete" }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+});
+
+describe("redirect サンプル (complete)", () => {
+  it("送信完了の案内を表示する", async () => {
+    await renderWithProviders(<RedirectCompleteScreen />);
+
+    expect(screen.getByText("送信が完了しました")).toBeOnTheScreen();
+  });
+});

--- a/apps/sandbox/src/app/(tabs)/(home)/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/index.tsx
@@ -50,6 +50,20 @@ export default function Index() {
             />
           ),
         },
+        {
+          href: "/redirect",
+          text: <Trans>Redirect</Trans>,
+          description: <Trans>非同期処理の完了後に画面遷移するサンプル</Trans>,
+          leadingIcon: (
+            <Ionicons
+              name="trail-sign-outline"
+              size={22}
+              color={tokens.color.text.secondary}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            />
+          ),
+        },
       ],
     },
     {

--- a/apps/sandbox/src/app/(tabs)/(home)/redirect/complete.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/redirect/complete.tsx
@@ -1,26 +1,15 @@
 import { Stack } from "expo-router";
-import { Trans, useLingui } from "@lingui/react/macro";
+import { useLingui } from "@lingui/react/macro";
 import type { ReactElement } from "react";
-import { ScreenScrollView } from "../../../../components/screen-scroll-view/ScreenScrollView";
-import { ThemedText } from "../../../../components/themed-text/ThemedText";
+import { RedirectCompleteScreen } from "../../../../features/redirect/RedirectCompleteScreen";
 
-export default function RedirectCompleteScreen(): ReactElement {
+export default function RedirectComplete(): ReactElement {
   const { t } = useLingui();
 
   return (
     <>
       <Stack.Screen.Title>{t`送信完了`}</Stack.Screen.Title>
-      <ScreenScrollView>
-        <ThemedText type="headline">
-          <Trans>送信が完了しました</Trans>
-        </ThemedText>
-        <ThemedText type="body">
-          <Trans>
-            処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace
-            によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。
-          </Trans>
-        </ThemedText>
-      </ScreenScrollView>
+      <RedirectCompleteScreen />
     </>
   );
 }

--- a/apps/sandbox/src/app/(tabs)/(home)/redirect/complete.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/redirect/complete.tsx
@@ -1,0 +1,26 @@
+import { Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { ReactElement } from "react";
+import { ScreenScrollView } from "../../../../components/screen-scroll-view/ScreenScrollView";
+import { ThemedText } from "../../../../components/themed-text/ThemedText";
+
+export default function RedirectCompleteScreen(): ReactElement {
+  const { t } = useLingui();
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`送信完了`}</Stack.Screen.Title>
+      <ScreenScrollView>
+        <ThemedText type="headline">
+          <Trans>送信が完了しました</Trans>
+        </ThemedText>
+        <ThemedText type="body">
+          <Trans>
+            処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace
+            によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。
+          </Trans>
+        </ThemedText>
+      </ScreenScrollView>
+    </>
+  );
+}

--- a/apps/sandbox/src/app/(tabs)/(home)/redirect/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/redirect/index.tsx
@@ -18,10 +18,6 @@ export default function RedirectDemo(): ReactElement {
   const { tokens } = useTheme();
   const [status, setStatus] = useState<SubmitStatus>("idle");
 
-  if (status === "done") {
-    return <Redirect href="/redirect/complete" />;
-  }
-
   const handleSubmit = () => {
     setStatus("pending");
     void simulateSubmit().then(() => setStatus("done"));
@@ -29,29 +25,41 @@ export default function RedirectDemo(): ReactElement {
 
   return (
     <>
+      {/*
+        Stack.Screen.Title は useSafeLayoutEffect でヘッダーオプションを登録/解除する。
+        status === "done" の分岐をトップレベルの早期 return にすると、Redirect への
+        差し替えと同時にこのタイトルがアンマウントされてオプション解除が走り、Redirect の
+        router.replace (画面のスタックからの除去) と競合して Android で
+        "ScreenStackFragment added into a non-stack container" のクラッシュを起こす。
+        画面が生きている間は常にマウントし、本文だけを出し分ける。
+      */}
       <Stack.Screen.Title>{t`Redirect`}</Stack.Screen.Title>
-      <ScreenScrollView>
-        <ThemedText type="body">
-          <Trans>
-            フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って
-            Redirect が完了画面へ遷移させます。
-          </Trans>
-        </ThemedText>
-        {status === "pending" ? (
-          <View style={[styles.pendingRow, { gap: tokens.spacing.sm }]}>
-            <ActivityIndicator color={tokens.color.text.secondary} />
-            <ThemedText type="body" tone="secondary">
-              <Trans>送信中…</Trans>
-            </ThemedText>
-          </View>
-        ) : (
-          <View style={styles.buttonRow}>
-            <Button onPress={handleSubmit}>
-              <Trans>送信する</Trans>
-            </Button>
-          </View>
-        )}
-      </ScreenScrollView>
+      {status === "done" ? (
+        <Redirect href="/redirect/complete" />
+      ) : (
+        <ScreenScrollView>
+          <ThemedText type="body">
+            <Trans>
+              フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って
+              Redirect が完了画面へ遷移させます。
+            </Trans>
+          </ThemedText>
+          {status === "pending" ? (
+            <View style={[styles.pendingRow, { gap: tokens.spacing.sm }]}>
+              <ActivityIndicator color={tokens.color.text.secondary} />
+              <ThemedText type="body" tone="secondary">
+                <Trans>送信中…</Trans>
+              </ThemedText>
+            </View>
+          ) : (
+            <View style={styles.buttonRow}>
+              <Button onPress={handleSubmit}>
+                <Trans>送信する</Trans>
+              </Button>
+            </View>
+          )}
+        </ScreenScrollView>
+      )}
     </>
   );
 }

--- a/apps/sandbox/src/app/(tabs)/(home)/redirect/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/redirect/index.tsx
@@ -1,75 +1,15 @@
-import { Redirect, Stack } from "expo-router";
-import { Trans, useLingui } from "@lingui/react/macro";
-import { type ReactElement, useState } from "react";
-import { ActivityIndicator, StyleSheet, View } from "react-native";
-import { Button } from "../../../../components/button/Button";
-import { ScreenScrollView } from "../../../../components/screen-scroll-view/ScreenScrollView";
-import { ThemedText } from "../../../../components/themed-text/ThemedText";
-import { useTheme } from "../../../../theme/useTheme";
-
-type SubmitStatus = "idle" | "pending" | "done";
-
-function simulateSubmit(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 1200));
-}
+import { Stack } from "expo-router";
+import { useLingui } from "@lingui/react/macro";
+import type { ReactElement } from "react";
+import { RedirectDemoScreen } from "../../../../features/redirect/RedirectDemoScreen";
 
 export default function RedirectDemo(): ReactElement {
   const { t } = useLingui();
-  const { tokens } = useTheme();
-  const [status, setStatus] = useState<SubmitStatus>("idle");
-
-  const handleSubmit = () => {
-    setStatus("pending");
-    void simulateSubmit().then(() => setStatus("done"));
-  };
 
   return (
     <>
-      {/*
-        Stack.Screen.Title は useSafeLayoutEffect でヘッダーオプションを登録/解除する。
-        status === "done" の分岐をトップレベルの早期 return にすると、Redirect への
-        差し替えと同時にこのタイトルがアンマウントされてオプション解除が走り、Redirect の
-        router.replace (画面のスタックからの除去) と競合して Android で
-        "ScreenStackFragment added into a non-stack container" のクラッシュを起こす。
-        画面が生きている間は常にマウントし、本文だけを出し分ける。
-      */}
       <Stack.Screen.Title>{t`Redirect`}</Stack.Screen.Title>
-      {status === "done" ? (
-        <Redirect href="/redirect/complete" />
-      ) : (
-        <ScreenScrollView>
-          <ThemedText type="body">
-            <Trans>
-              フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って
-              Redirect が完了画面へ遷移させます。
-            </Trans>
-          </ThemedText>
-          {status === "pending" ? (
-            <View style={[styles.pendingRow, { gap: tokens.spacing.sm }]}>
-              <ActivityIndicator color={tokens.color.text.secondary} />
-              <ThemedText type="body" tone="secondary">
-                <Trans>送信中…</Trans>
-              </ThemedText>
-            </View>
-          ) : (
-            <View style={styles.buttonRow}>
-              <Button onPress={handleSubmit}>
-                <Trans>送信する</Trans>
-              </Button>
-            </View>
-          )}
-        </ScreenScrollView>
-      )}
+      <RedirectDemoScreen />
     </>
   );
 }
-
-const styles = StyleSheet.create({
-  pendingRow: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  buttonRow: {
-    flexDirection: "row",
-  },
-});

--- a/apps/sandbox/src/app/(tabs)/(home)/redirect/index.tsx
+++ b/apps/sandbox/src/app/(tabs)/(home)/redirect/index.tsx
@@ -1,0 +1,67 @@
+import { Redirect, Stack } from "expo-router";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { type ReactElement, useState } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { Button } from "../../../../components/button/Button";
+import { ScreenScrollView } from "../../../../components/screen-scroll-view/ScreenScrollView";
+import { ThemedText } from "../../../../components/themed-text/ThemedText";
+import { useTheme } from "../../../../theme/useTheme";
+
+type SubmitStatus = "idle" | "pending" | "done";
+
+function simulateSubmit(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 1200));
+}
+
+export default function RedirectDemo(): ReactElement {
+  const { t } = useLingui();
+  const { tokens } = useTheme();
+  const [status, setStatus] = useState<SubmitStatus>("idle");
+
+  if (status === "done") {
+    return <Redirect href="/redirect/complete" />;
+  }
+
+  const handleSubmit = () => {
+    setStatus("pending");
+    void simulateSubmit().then(() => setStatus("done"));
+  };
+
+  return (
+    <>
+      <Stack.Screen.Title>{t`Redirect`}</Stack.Screen.Title>
+      <ScreenScrollView>
+        <ThemedText type="body">
+          <Trans>
+            フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って
+            Redirect が完了画面へ遷移させます。
+          </Trans>
+        </ThemedText>
+        {status === "pending" ? (
+          <View style={[styles.pendingRow, { gap: tokens.spacing.sm }]}>
+            <ActivityIndicator color={tokens.color.text.secondary} />
+            <ThemedText type="body" tone="secondary">
+              <Trans>送信中…</Trans>
+            </ThemedText>
+          </View>
+        ) : (
+          <View style={styles.buttonRow}>
+            <Button onPress={handleSubmit}>
+              <Trans>送信する</Trans>
+            </Button>
+          </View>
+        )}
+      </ScreenScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  pendingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  buttonRow: {
+    flexDirection: "row",
+  },
+});

--- a/apps/sandbox/src/features/redirect/RedirectCompleteScreen.tsx
+++ b/apps/sandbox/src/features/redirect/RedirectCompleteScreen.tsx
@@ -1,0 +1,20 @@
+import { Trans } from "@lingui/react/macro";
+import type { ReactElement } from "react";
+import { ScreenScrollView } from "../../components/screen-scroll-view/ScreenScrollView";
+import { ThemedText } from "../../components/themed-text/ThemedText";
+
+export function RedirectCompleteScreen(): ReactElement {
+  return (
+    <ScreenScrollView>
+      <ThemedText type="headline">
+        <Trans>送信が完了しました</Trans>
+      </ThemedText>
+      <ThemedText type="body">
+        <Trans>
+          処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace
+          によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。
+        </Trans>
+      </ThemedText>
+    </ScreenScrollView>
+  );
+}

--- a/apps/sandbox/src/features/redirect/RedirectDemoScreen.test.tsx
+++ b/apps/sandbox/src/features/redirect/RedirectDemoScreen.test.tsx
@@ -1,40 +1,31 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
-import type { ReactNode } from "react";
-import RedirectCompleteScreen from "../app/(tabs)/(home)/redirect/complete";
-import RedirectDemo from "../app/(tabs)/(home)/redirect/index";
-import { renderWithProviders } from "../test-utils/render";
+import { renderWithProviders } from "../../test-utils/render";
+import { RedirectDemoScreen } from "./RedirectDemoScreen";
 
 const mockRedirect = jest.fn();
 
-// Stack.Screen.Title は実際のナビゲーションコンテキストを要求するため、
-// 画面遷移(Redirect)の検証に不要な部分ごとモックする。
 jest.mock("expo-router", () => ({
   Redirect: (props: { href: string }) => {
     mockRedirect(props);
     return null;
   },
-  Stack: {
-    Screen: {
-      Title: (_props: { children?: ReactNode }) => null,
-    },
-  },
 }));
 
-describe("redirect サンプル (index)", () => {
+describe("RedirectDemoScreen", () => {
   beforeEach(() => {
     mockRedirect.mockClear();
   });
 
   it("初期表示では送信ボタンを表示し、Redirect は呼ばれない", async () => {
-    await renderWithProviders(<RedirectDemo />);
+    await renderWithProviders(<RedirectDemoScreen />);
 
     expect(screen.getByText("送信する")).toBeOnTheScreen();
     expect(mockRedirect).not.toHaveBeenCalled();
   });
 
   it("送信すると送信中の表示に切り替わり、完了後に /redirect/complete への Redirect が呼ばれる", async () => {
-    await renderWithProviders(<RedirectDemo />);
+    await renderWithProviders(<RedirectDemoScreen />);
 
     await fireEvent.press(screen.getByText("送信する"));
 
@@ -48,13 +39,5 @@ describe("redirect サンプル (index)", () => {
       },
       { timeout: 2000 },
     );
-  });
-});
-
-describe("redirect サンプル (complete)", () => {
-  it("送信完了の案内を表示する", async () => {
-    await renderWithProviders(<RedirectCompleteScreen />);
-
-    expect(screen.getByText("送信が完了しました")).toBeOnTheScreen();
   });
 });

--- a/apps/sandbox/src/features/redirect/RedirectDemoScreen.tsx
+++ b/apps/sandbox/src/features/redirect/RedirectDemoScreen.tsx
@@ -1,0 +1,78 @@
+import { Redirect } from "expo-router";
+import { Trans } from "@lingui/react/macro";
+import { type ReactElement, useState } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { Button } from "../../components/button/Button";
+import { ScreenScrollView } from "../../components/screen-scroll-view/ScreenScrollView";
+import { ThemedText } from "../../components/themed-text/ThemedText";
+import { useTheme } from "../../theme/useTheme";
+
+type SubmitStatus = "idle" | "pending" | "done";
+
+function simulateSubmit(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 1200));
+}
+
+export function RedirectDemoScreen(): ReactElement {
+  const [status, setStatus] = useState<SubmitStatus>("idle");
+
+  const handleSubmit = () => {
+    setStatus("pending");
+    void simulateSubmit().then(() => setStatus("done"));
+  };
+
+  if (status === "done") {
+    return <Redirect href="/redirect/complete" />;
+  }
+
+  return (
+    <ScreenScrollView>
+      <ThemedText type="body">
+        <Trans>
+          フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って
+          Redirect が完了画面へ遷移させます。
+        </Trans>
+      </ThemedText>
+      <ActionArea status={status} onSubmit={handleSubmit} />
+    </ScreenScrollView>
+  );
+}
+
+interface ActionAreaProps {
+  status: Exclude<SubmitStatus, "done">;
+  onSubmit: () => void;
+}
+
+function ActionArea({ status, onSubmit }: ActionAreaProps): ReactElement {
+  const { tokens } = useTheme();
+
+  switch (status) {
+    case "idle":
+      return (
+        <View style={styles.buttonRow}>
+          <Button onPress={onSubmit}>
+            <Trans>送信する</Trans>
+          </Button>
+        </View>
+      );
+    case "pending":
+      return (
+        <View style={[styles.pendingRow, { gap: tokens.spacing.sm }]}>
+          <ActivityIndicator color={tokens.color.text.secondary} />
+          <ThemedText type="body" tone="secondary">
+            <Trans>送信中…</Trans>
+          </ThemedText>
+        </View>
+      );
+  }
+}
+
+const styles = StyleSheet.create({
+  pendingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  buttonRow: {
+    flexDirection: "row",
+  },
+});

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -1436,11 +1436,11 @@ msgstr "Advanced settings"
 msgid "送信が完了しました"
 msgstr "Submission complete"
 
-#: src/features/redirect/RedirectDemoScreen.tsx:47
+#: src/features/redirect/RedirectDemoScreen.tsx:54
 msgid "送信する"
 msgstr "Submit"
 
-#: src/features/redirect/RedirectDemoScreen.tsx:40
+#: src/features/redirect/RedirectDemoScreen.tsx:63
 msgid "送信中…"
 msgstr "Submitting…"
 

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -523,7 +523,7 @@ msgid "React Query / fetch サンプル (準備中)"
 msgstr "React Query / fetch sample (coming soon)"
 
 #: src/app/(tabs)/(home)/index.tsx:55
-#: src/app/(tabs)/(home)/redirect/index.tsx:32
+#: src/app/(tabs)/(home)/redirect/index.tsx:11
 msgid "Redirect"
 msgstr "Redirect"
 
@@ -952,7 +952,7 @@ msgstr "Falls back to transparentModal because Android has no native equivalent 
 msgid "はじめる"
 msgstr "Get started"
 
-#: src/app/(tabs)/(home)/redirect/index.tsx:35
+#: src/features/redirect/RedirectDemoScreen.tsx:31
 msgid "フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って Redirect が完了画面へ遷移させます。"
 msgstr "A sample that mimics an async operation like a form submission. Pressing \"Submit\" waits for the operation to complete, then Redirect navigates to the completion screen."
 
@@ -1232,7 +1232,7 @@ msgstr "Share"
 msgid "共有先を選択"
 msgstr "Choose where to share"
 
-#: src/app/(tabs)/(home)/redirect/complete.tsx:18
+#: src/features/redirect/RedirectCompleteScreen.tsx:13
 msgid "処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。"
 msgstr "Redirect detected that the operation completed and navigated you to this screen. Because Redirect performs a replace navigation internally, the pre-submission screen isn't kept in history. Pressing back skips the form and returns straight to the list screen (this also prevents duplicate submissions)."
 
@@ -1432,19 +1432,19 @@ msgstr "Settings screen"
 msgid "詳細設定"
 msgstr "Advanced settings"
 
-#: src/app/(tabs)/(home)/redirect/complete.tsx:15
+#: src/features/redirect/RedirectCompleteScreen.tsx:10
 msgid "送信が完了しました"
 msgstr "Submission complete"
 
-#: src/app/(tabs)/(home)/redirect/index.tsx:50
+#: src/features/redirect/RedirectDemoScreen.tsx:47
 msgid "送信する"
 msgstr "Submit"
 
-#: src/app/(tabs)/(home)/redirect/index.tsx:44
+#: src/features/redirect/RedirectDemoScreen.tsx:40
 msgid "送信中…"
 msgstr "Submitting…"
 
-#: src/app/(tabs)/(home)/redirect/complete.tsx:12
+#: src/app/(tabs)/(home)/redirect/complete.tsx:11
 msgid "送信完了"
 msgstr "Submission Complete"
 

--- a/apps/sandbox/src/locales/en/messages.po
+++ b/apps/sandbox/src/locales/en/messages.po
@@ -518,9 +518,14 @@ msgstr "push vs navigate"
 msgid "push ボタンを数回押すと画面数が増えます。その後 navigate ボタンを押すと、最初の詳細まで戻り（重複を作らず）画面数が減ります。"
 msgstr "Tap the push button a few times to increase the screen count. Then tap the navigate button to return to the first detail (without creating a duplicate), which decreases the count."
 
-#: src/app/(tabs)/(home)/index.tsx:62
+#: src/app/(tabs)/(home)/index.tsx:76
 msgid "React Query / fetch サンプル (準備中)"
 msgstr "React Query / fetch sample (coming soon)"
+
+#: src/app/(tabs)/(home)/index.tsx:55
+#: src/app/(tabs)/(home)/redirect/index.tsx:32
+msgid "Redirect"
+msgstr "Redirect"
 
 #: src/app/(tabs)/(home)/expo-ui/event-form/index.tsx:96
 msgid "SegmentedControl"
@@ -873,7 +878,7 @@ msgstr "Full-screen modal on the in-tab Stack"
 msgid "タブ内 Stack 上の背景透過モーダル"
 msgstr "Transparent modal on the in-tab Stack"
 
-#: src/app/(tabs)/(home)/index.tsx:61
+#: src/app/(tabs)/(home)/index.tsx:75
 msgid "データ取得"
 msgstr "Data fetching"
 
@@ -946,6 +951,10 @@ msgstr "Falls back to transparentModal because Android has no native equivalent 
 #: src/app/expo-ui/onboarding/index.tsx:117
 msgid "はじめる"
 msgstr "Get started"
+
+#: src/app/(tabs)/(home)/redirect/index.tsx:35
+msgid "フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って Redirect が完了画面へ遷移させます。"
+msgstr "A sample that mimics an async operation like a form submission. Pressing \"Submit\" waits for the operation to complete, then Redirect navigates to the completion screen."
 
 #: src/app/(tabs)/(home)/navigation-patterns/card/in-tab-none.tsx:37
 msgid "プログラムによる画面差し替えや、独自トランジションを別途実装する場合など、ネイティブの 遷移アニメーションを抑制したいケースに向く。"
@@ -1020,7 +1029,7 @@ msgid "ヘッダー左の戻るボタン、または OS のジェスチャーで
 msgstr "Return to the previous screen via the back button in the header or the OS gesture. The pop is also a cross-fade. Comparing against the in-tab variant with `animation` unspecified (slide-in from the right) makes the difference easy to see."
 
 #: src/app/(tabs)/_layout.tsx:27
-#: src/app/(tabs)/(home)/index.tsx:79
+#: src/app/(tabs)/(home)/index.tsx:93
 msgid "ホーム"
 msgstr "Home"
 
@@ -1223,6 +1232,10 @@ msgstr "Share"
 msgid "共有先を選択"
 msgstr "Choose where to share"
 
+#: src/app/(tabs)/(home)/redirect/complete.tsx:18
+msgid "処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。"
+msgstr "Redirect detected that the operation completed and navigated you to this screen. Because Redirect performs a replace navigation internally, the pre-submission screen isn't kept in history. Pressing back skips the form and returns straight to the list screen (this also prevents duplicate submissions)."
+
 #: src/app/(tabs)/(home)/expo-ui/settings/index.tsx:118
 msgid "利用状況データを送信"
 msgstr "Send usage data"
@@ -1321,7 +1334,7 @@ msgstr "Instead of the default OS-standard transition (often slide-in from the r
 msgid "次へ"
 msgstr "Next"
 
-#: src/app/(tabs)/(home)/index.tsx:56
+#: src/app/(tabs)/(home)/index.tsx:70
 msgid "準備中"
 msgstr "Coming soon"
 
@@ -1419,6 +1432,22 @@ msgstr "Settings screen"
 msgid "詳細設定"
 msgstr "Advanced settings"
 
+#: src/app/(tabs)/(home)/redirect/complete.tsx:15
+msgid "送信が完了しました"
+msgstr "Submission complete"
+
+#: src/app/(tabs)/(home)/redirect/index.tsx:50
+msgid "送信する"
+msgstr "Submit"
+
+#: src/app/(tabs)/(home)/redirect/index.tsx:44
+msgid "送信中…"
+msgstr "Submitting…"
+
+#: src/app/(tabs)/(home)/redirect/complete.tsx:12
+msgid "送信完了"
+msgstr "Submission Complete"
+
 #: src/app/(tabs)/(home)/expo-ui/settings/index.tsx:74
 msgid "通知"
 msgstr "Notifications"
@@ -1456,6 +1485,10 @@ msgstr "Start time"
 #: src/app/(tabs)/(home)/expo-ui/event-form/index.tsx:36
 msgid "非公開"
 msgstr "Private"
+
+#: src/app/(tabs)/(home)/index.tsx:56
+msgid "非同期処理の完了後に画面遷移するサンプル"
+msgstr "A sample that navigates after an async operation completes"
 
 #: src/app/(tabs)/(home)/expo-ui/event-form/index.tsx:40
 msgid "飲み会"

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -1436,11 +1436,11 @@ msgstr "詳細設定"
 msgid "送信が完了しました"
 msgstr "送信が完了しました"
 
-#: src/features/redirect/RedirectDemoScreen.tsx:47
+#: src/features/redirect/RedirectDemoScreen.tsx:54
 msgid "送信する"
 msgstr "送信する"
 
-#: src/features/redirect/RedirectDemoScreen.tsx:40
+#: src/features/redirect/RedirectDemoScreen.tsx:63
 msgid "送信中…"
 msgstr "送信中…"
 

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -523,7 +523,7 @@ msgid "React Query / fetch サンプル (準備中)"
 msgstr "React Query / fetch サンプル (準備中)"
 
 #: src/app/(tabs)/(home)/index.tsx:55
-#: src/app/(tabs)/(home)/redirect/index.tsx:32
+#: src/app/(tabs)/(home)/redirect/index.tsx:11
 msgid "Redirect"
 msgstr "Redirect"
 
@@ -952,7 +952,7 @@ msgstr "ネイティブの対応 presentation がないため transparentModal �
 msgid "はじめる"
 msgstr "はじめる"
 
-#: src/app/(tabs)/(home)/redirect/index.tsx:35
+#: src/features/redirect/RedirectDemoScreen.tsx:31
 msgid "フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って Redirect が完了画面へ遷移させます。"
 msgstr "フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って Redirect が完了画面へ遷移させます。"
 
@@ -1232,7 +1232,7 @@ msgstr "共有"
 msgid "共有先を選択"
 msgstr "共有先を選択"
 
-#: src/app/(tabs)/(home)/redirect/complete.tsx:18
+#: src/features/redirect/RedirectCompleteScreen.tsx:13
 msgid "処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。"
 msgstr "処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。"
 
@@ -1432,19 +1432,19 @@ msgstr "設定画面"
 msgid "詳細設定"
 msgstr "詳細設定"
 
-#: src/app/(tabs)/(home)/redirect/complete.tsx:15
+#: src/features/redirect/RedirectCompleteScreen.tsx:10
 msgid "送信が完了しました"
 msgstr "送信が完了しました"
 
-#: src/app/(tabs)/(home)/redirect/index.tsx:50
+#: src/features/redirect/RedirectDemoScreen.tsx:47
 msgid "送信する"
 msgstr "送信する"
 
-#: src/app/(tabs)/(home)/redirect/index.tsx:44
+#: src/features/redirect/RedirectDemoScreen.tsx:40
 msgid "送信中…"
 msgstr "送信中…"
 
-#: src/app/(tabs)/(home)/redirect/complete.tsx:12
+#: src/app/(tabs)/(home)/redirect/complete.tsx:11
 msgid "送信完了"
 msgstr "送信完了"
 

--- a/apps/sandbox/src/locales/ja/messages.po
+++ b/apps/sandbox/src/locales/ja/messages.po
@@ -518,9 +518,14 @@ msgstr "push と navigate の違い"
 msgid "push ボタンを数回押すと画面数が増えます。その後 navigate ボタンを押すと、最初の詳細まで戻り（重複を作らず）画面数が減ります。"
 msgstr "push ボタンを数回押すと画面数が増えます。その後 navigate ボタンを押すと、最初の詳細まで戻り（重複を作らず）画面数が減ります。"
 
-#: src/app/(tabs)/(home)/index.tsx:62
+#: src/app/(tabs)/(home)/index.tsx:76
 msgid "React Query / fetch サンプル (準備中)"
 msgstr "React Query / fetch サンプル (準備中)"
+
+#: src/app/(tabs)/(home)/index.tsx:55
+#: src/app/(tabs)/(home)/redirect/index.tsx:32
+msgid "Redirect"
+msgstr "Redirect"
 
 #: src/app/(tabs)/(home)/expo-ui/event-form/index.tsx:96
 msgid "SegmentedControl"
@@ -873,7 +878,7 @@ msgstr "タブ内 Stack 上の全画面モーダル"
 msgid "タブ内 Stack 上の背景透過モーダル"
 msgstr "タブ内 Stack 上の背景透過モーダル"
 
-#: src/app/(tabs)/(home)/index.tsx:61
+#: src/app/(tabs)/(home)/index.tsx:75
 msgid "データ取得"
 msgstr "データ取得"
 
@@ -946,6 +951,10 @@ msgstr "ネイティブの対応 presentation がないため transparentModal �
 #: src/app/expo-ui/onboarding/index.tsx:117
 msgid "はじめる"
 msgstr "はじめる"
+
+#: src/app/(tabs)/(home)/redirect/index.tsx:35
+msgid "フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って Redirect が完了画面へ遷移させます。"
+msgstr "フォーム送信のような非同期処理を模したサンプルです。「送信する」を押すと、処理の完了を待って Redirect が完了画面へ遷移させます。"
 
 #: src/app/(tabs)/(home)/navigation-patterns/card/in-tab-none.tsx:37
 msgid "プログラムによる画面差し替えや、独自トランジションを別途実装する場合など、ネイティブの 遷移アニメーションを抑制したいケースに向く。"
@@ -1020,7 +1029,7 @@ msgid "ヘッダー左の戻るボタン、または OS のジェスチャーで
 msgstr "ヘッダー左の戻るボタン、または OS のジェスチャーで前画面に戻る。戻り (pop) も同じく クロスフェードになる。animation 未指定の in-tab 版 (右からスライド) との差分を見比べると 分かりやすい。"
 
 #: src/app/(tabs)/_layout.tsx:27
-#: src/app/(tabs)/(home)/index.tsx:79
+#: src/app/(tabs)/(home)/index.tsx:93
 msgid "ホーム"
 msgstr "ホーム"
 
@@ -1223,6 +1232,10 @@ msgstr "共有"
 msgid "共有先を選択"
 msgstr "共有先を選択"
 
+#: src/app/(tabs)/(home)/redirect/complete.tsx:18
+msgid "処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。"
+msgstr "処理の完了を検知した Redirect によってこの画面に遷移しました。Redirect は内部で replace によるナビゲーションを行うため、送信前の画面は履歴に残りません。戻るボタンを押すと送信前のフォームを経由せず、一覧画面まで戻ります(二重送信の防止にもなります)。"
+
 #: src/app/(tabs)/(home)/expo-ui/settings/index.tsx:118
 msgid "利用状況データを送信"
 msgstr "利用状況データを送信"
@@ -1321,7 +1334,7 @@ msgstr "既定の OS 標準遷移 (多くは右からスライド) ではなく�
 msgid "次へ"
 msgstr "次へ"
 
-#: src/app/(tabs)/(home)/index.tsx:56
+#: src/app/(tabs)/(home)/index.tsx:70
 msgid "準備中"
 msgstr "準備中"
 
@@ -1419,6 +1432,22 @@ msgstr "設定画面"
 msgid "詳細設定"
 msgstr "詳細設定"
 
+#: src/app/(tabs)/(home)/redirect/complete.tsx:15
+msgid "送信が完了しました"
+msgstr "送信が完了しました"
+
+#: src/app/(tabs)/(home)/redirect/index.tsx:50
+msgid "送信する"
+msgstr "送信する"
+
+#: src/app/(tabs)/(home)/redirect/index.tsx:44
+msgid "送信中…"
+msgstr "送信中…"
+
+#: src/app/(tabs)/(home)/redirect/complete.tsx:12
+msgid "送信完了"
+msgstr "送信完了"
+
 #: src/app/(tabs)/(home)/expo-ui/settings/index.tsx:74
 msgid "通知"
 msgstr "通知"
@@ -1456,6 +1485,10 @@ msgstr "開始時刻"
 #: src/app/(tabs)/(home)/expo-ui/event-form/index.tsx:36
 msgid "非公開"
 msgstr "非公開"
+
+#: src/app/(tabs)/(home)/index.tsx:56
+msgid "非同期処理の完了後に画面遷移するサンプル"
+msgstr "非同期処理の完了後に画面遷移するサンプル"
 
 #: src/app/(tabs)/(home)/expo-ui/event-form/index.tsx:40
 msgid "飲み会"

--- a/docs/conditional-rendering.md
+++ b/docs/conditional-rendering.md
@@ -1,0 +1,73 @@
+# JSX の条件分岐
+
+## 方針
+
+DRY（重複排除）を優先するあまり、1つの状態の挙動を理解するために複数の条件分岐を頭の中で合成しなければならない構造になっていないか注意する。条件が複数箇所に散らばるほど、人・コーディングエージェントどちらにとっても「この状態のとき何が表示されるか」を把握するための読解コストが増える。
+
+これは「常にこう書け」という特定の書き方の強制ではなく、DRY とのトレードオフとして意識してほしい観点。状態の数が少なく重複する部分も小さいうちは重複が実害を持たないことも多いが、状態が増えたり分岐が入れ子になってきたら、多少の重複を許容してでも各状態の挙動を1箇所にまとめる方を優先する。
+
+## テクニックの例: ガード節 + 絞り込んだ型を持つ switch
+
+3状態以上の相互排他的な分岐であれば、独立した `&&` 条件を並べる代わりに、特殊ケースをガード節で early return し、残りは絞り込んだ型（`Exclude<T, "...">` 等）を持つ switch 文のサブコンポーネントに切り出す、という手段が有効なことがある。
+
+- switch の各 case は自己完結していて、他の条件と合成せずに読める
+- switch は構造的に排他的なので、複数条件が同時に成立しないことを自分で確認する必要がない
+- TypeScript の網羅性チェックにより、状態の網羅漏れがコンパイルエラーとして検出できる
+
+### Before: 独立した `&&` 条件が散らばっている
+
+```tsx
+return (
+  <>
+    {status === "done" && <Redirect href="/redirect/complete" />}
+    {status !== "done" && (
+      <ScreenScrollView>
+        <ThemedText type="body">
+          <Trans>...</Trans>
+        </ThemedText>
+        {status === "pending" && <View style={styles.pendingRow}>...</View>}
+        {status === "idle" && <View style={styles.buttonRow}>...</View>}
+      </ScreenScrollView>
+    )}
+  </>
+);
+```
+
+`status === "pending"` の時に何が表示されるかを知るには4つの条件をすべて評価し、`pending` と `idle` が同時に true にならないことを自分で確認する必要がある。
+
+### After: ガード節 + 絞り込んだ型を持つ switch
+
+```tsx
+if (status === "done") {
+  return <Redirect href="/redirect/complete" />;
+}
+
+return (
+  <ScreenScrollView>
+    <ThemedText type="body">
+      <Trans>...</Trans>
+    </ThemedText>
+    <ActionArea status={status} onSubmit={handleSubmit} />
+  </ScreenScrollView>
+);
+
+interface ActionAreaProps {
+  status: Exclude<SubmitStatus, "done">;
+  onSubmit: () => void;
+}
+
+function ActionArea({ status, onSubmit }: ActionAreaProps): ReactElement {
+  switch (status) {
+    case "idle":
+      return <View style={styles.buttonRow}>...</View>;
+    case "pending":
+      return <View style={styles.pendingRow}>...</View>;
+  }
+}
+```
+
+`case "pending":` を読めばそのケースの全体が分かる。`ActionArea` が受け取れる `status` の型が `Exclude<SubmitStatus, "done">` なので、`done` を渡すことはコンパイル時に防がれる。
+
+## 実例
+
+[`apps/sandbox/src/features/redirect/RedirectDemoScreen.tsx`](../apps/sandbox/src/features/redirect/RedirectDemoScreen.tsx)

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -10,11 +10,11 @@
 | `features/<name>/` | **単一機能専用**のコード。内部構成は機能の形に合わせる（一律には規定しない）。テストは対象と同じディレクトリに co-location |
 | `components/` | **2機能以上から使われる**共有 UI |
 | `theme/` `i18n/` `locales/` `test-utils/` | 横断インフラ（テーマ・国際化・lingui 生成物・テストユーティリティ） |
-| `__tests__/` | `app/` 配下の画面（route）自体の挙動を検証するテスト専用 |
 
 - 新しいレイヤーディレクトリ（`utils/` `hooks/` `constants/` など）は第1階層に作らない。ユーティリティや hooks は利用する機能・コンポーネントのディレクトリへ co-location する
 - `app/` にルート以外のファイルを置かないのは Expo Router の制約と公式方針による（app/ 配下のファイルはルートとして解釈される）。参考: [Expo Router: Core concepts](https://docs.expo.dev/router/basics/core-concepts/)
-  - この制約により `app/` 配下の画面は co-location でテストできないため、`__tests__/` から対象の画面コンポーネントを直接 import してテストする（`app` → `features`/`components` と同様、依存方向のルールはテストコードには適用しない）
+  - この制約により `app/` 配下の画面はテストを co-location できない。画面ファイルは `Stack.Screen.Title` の設定と `features/` のコンポーネント呼び出しだけの薄いラッパーに保ち、実際のロジック・表示は `features/<name>/` に切り出してそちらで co-location テストする
+  - 個別画面ではなく実際のルーティング挙動（複数ルートをまたぐ画面遷移など）そのものを検証したい場合は、第1階層に `__tests__/` を作り、対象の画面コンポーネントを直接 import してテストする（[Expo Router: Testing](https://docs.expo.dev/router/reference/testing/) が明示的に推奨する配置。`app` → `features`/`components` と同様、依存方向のルールはテストコードには適用しない）
 
 ## 機能と共有の線引き
 

--- a/docs/file-structure.md
+++ b/docs/file-structure.md
@@ -10,9 +10,11 @@
 | `features/<name>/` | **単一機能専用**のコード。内部構成は機能の形に合わせる（一律には規定しない）。テストは対象と同じディレクトリに co-location |
 | `components/` | **2機能以上から使われる**共有 UI |
 | `theme/` `i18n/` `locales/` `test-utils/` | 横断インフラ（テーマ・国際化・lingui 生成物・テストユーティリティ） |
+| `__tests__/` | `app/` 配下の画面（route）自体の挙動を検証するテスト専用 |
 
 - 新しいレイヤーディレクトリ（`utils/` `hooks/` `constants/` など）は第1階層に作らない。ユーティリティや hooks は利用する機能・コンポーネントのディレクトリへ co-location する
 - `app/` にルート以外のファイルを置かないのは Expo Router の制約と公式方針による（app/ 配下のファイルはルートとして解釈される）。参考: [Expo Router: Core concepts](https://docs.expo.dev/router/basics/core-concepts/)
+  - この制約により `app/` 配下の画面は co-location でテストできないため、`__tests__/` から対象の画面コンポーネントを直接 import してテストする（`app` → `features`/`components` と同様、依存方向のルールはテストコードには適用しない）
 
 ## 機能と共有の線引き
 


### PR DESCRIPTION
## 概要

Expo Router の `Redirect` コンポーネントを使ったサンプルをホームのサンプル一覧に追加する。フォーム送信のような非同期処理の完了を待ってから `<Redirect>` で結果画面へ遷移する、という実用的なシナリオを実装した。

## 背景・動機

このリポジトリには `Redirect` の使用例がまだ存在しなかった。依頼内容は「何らかのリクエストが完了した後にリダイレクトする」イメージのサンプルで、公式ドキュメント（[Expo Router: Redirects](https://docs.expo.dev/router/reference/redirects/)）が示す「state に応じて `<Redirect href="..." />` を返す」パターンの実践例にあたる。

## アプローチ

- スコープはユーザー確認の結果、宣言的な `<Redirect>` コンポーネントのみとし、`useRouter` + `useFocusEffect` + `router.replace` による命令的な代替手段の解説サンプルは対象外とした（`Redirect` 自体を使わないため依頼範囲外と判断）
- 状態は `SubmitStatus`（`"idle" | "pending" | "done"`）の `useState` のみで完結させた。当初は認証ガード的な複数画面 + Context 構成を検討したが、要望が単一画面で閉じるシナリオだったため設計を変更した
- 実装後、Android Emulator での実機確認で `Stack.Screen.Title` と `Redirect` の早期 return 競合による native クラッシュ（`ScreenStackFragment added into a non-stack container`）を発見・修正した。JS 環境で動く Jest テストでは検出できないネイティブ層（react-native-screens の Fragment 管理）の不具合だった
- テスト方針の議論を経て、画面ロジックを `features/redirect/` に切り出し `app/` 側を薄いラッパーにすることで、テストを通常の co-location 配置にできるよう改善した（Expo Router は `app/` 配下に非ルートファイルを置けない制約があるため）
- JSX の条件分岐（3状態以上の相互排他分岐）に関する設計指針を `docs/conditional-rendering.md` として言語化し、`CLAUDE.md` から参照させた

## レビューポイント

- `docs/conditional-rendering.md` の設計指針（DRY とのトレードオフとしてガード節+switchを一手段として提示）が妥当か
- Android クラッシュの修正（`RedirectDemoScreen.tsx`）は実機で再発しないことを確認済みだが、念のため再確認歓迎

🤖 Generated with [Claude Code](https://claude.com/claude-code)