### PR TITLE
fix(sandbox): eas-update-cleanup の名前衝突を解消するため scripts エントリを削除

### DIFF
--- a/.github/workflows/eas-update-cleanup.yml
+++ b/.github/workflows/eas-update-cleanup.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cleanup old EAS Updates
         # tooling パッケージの bin を apps/sandbox の cwd で実行 (eas のプロジェクト解決のため)
-        run: pnpm run eas-update-cleanup
+        run: pnpm exec eas-update-cleanup
         working-directory: apps/sandbox
         env:
           BRANCH: development

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -20,8 +20,7 @@
     "lingui:extract": "lingui extract --clean",
     "lingui:compile": "lingui compile",
     "lingui:compile-if-needed": "[ -f src/locales/en/messages.ts ] || pnpm run lingui:compile",
-    "lingui:check": "lingui compile --strict",
-    "eas-update-cleanup": "eas-update-cleanup"
+    "lingui:check": "lingui compile --strict"
   },
   "dependencies": {
     "@expo/material-symbols": "^0.1.1",


### PR DESCRIPTION
## 概要

`apps/sandbox` で `expo-doctor` を実行すると、`package.json` の scripts に登録していた `eas-update-cleanup` が `packages/tooling` の bin 名と完全一致するため "Check package.json for common issues" が failed になっていた問題を解消する。

## 背景・動機

`packages/tooling` は `bin: { "eas-update-cleanup": "./src/eas-update-cleanup/cli.ts" }` を公開しており、`apps/sandbox/package.json` の scripts に同名の `"eas-update-cleanup": "eas-update-cleanup"` を登録していたため、expo-doctor が名前衝突として検出していた（Expo SDK 56→57 アップグレードで新たに生じた問題ではなく、tooling パッケージ切り出し時点から既知の状態）。

## アプローチ

当初は scripts 側のキー名変更を検討し、以下の順で案を出した:

1. `run-eas-update-cleanup`
2. `eas:update-cleanup`（コロン区切り）→ このリポジトリのコロン区切りは「親スクリプトからまとめて実行される」ことを表す命名規約であり、単発コマンドの名前空間目的には合わないとの指摘を受け却下
3. `cleanup-eas-updates`（ハイフン区切り）→ 一旦この案で確定

しかし、ワークフロー側の呼び出し（`.github/workflows/eas-update-cleanup.yml`）はオプションの組み立てもなく、同一リポジトリ内の自作ツールを1箇所から呼ぶだけの用途だったため、scripts に別名を用意する優位性（`pnpm run` での一覧表示程度）が薄いとの指摘を踏まえ、名前を変えて残す方針自体を撤回した。

最終的に `apps/sandbox/package.json` から scripts エントリを削除し、ワークフローから `pnpm exec eas-update-cleanup` で `packages/tooling` の bin を直接呼び出す形に変更した。

## 検証

- `pnpm install` 後に `pnpm exec eas-update-cleanup` を実行し、`packages/tooling` の実装（`cli.ts`）に到達することを確認（`eas` 未ログインによる JSON パースエラーは環境要因で想定内）
- `apps/sandbox` で `pnpm dlx expo-doctor` を実行し 20/20 に回復することを確認

## Test plan

- [x] `pnpm dlx expo-doctor`（apps/sandbox 内で実行）が 20/20 で通過する
- [x] `pnpm exec eas-update-cleanup` が `packages/tooling` の実装を正しく呼び出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)