### PR TITLE
build(sandbox): babel.config.js が参照する babel-preset-expo を明示的な依存に追加

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -68,6 +68,7 @@
     "@lingui/format-po": "^6.0.0",
     "@testing-library/react-native": "^14.0.0",
     "@types/react": "~19.2.0",
+    "babel-preset-expo": "~57.0.2",
     "eslint": "^9.39.2",
     "eslint-config-expo": "~57.0.0",
     "eslint-plugin-oxlint": "^1.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.15
+      babel-preset-expo:
+        specifier: ~57.0.2
+        version: 57.0.2(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@57.0.4)(react-refresh@0.14.2)
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.7.0)


### PR DESCRIPTION
## 概要

`babel.config.js` が直接参照している `babel-preset-expo` を `apps/sandbox/package.json` の `devDependencies` に明示的に追加する。

## 背景・動機

`babel.config.js` は `presets: ["babel-preset-expo"]` として直接参照しているが、`package.json` のどちらの依存にも `babel-preset-expo` が明示されておらず、pnpm の hoisted 構成（`jest-expo` 等の transitive dependency 経由）に暗黙的に依存していた。expo-upgrade スキルの "Remove implicit packages from package.json: `@babel/core`, `babel-preset-expo`, `expo-constants`" という一般的な提案を検証する過程で見つかった。

## アプローチ

暗黙化（package.json から削除して hoisting に委ねる）という方向も検討したが、以下の理由で明示を維持する方針にした。

- pnpm のデフォルト（isolated）からあえて hoisted 構成へ寄せているこのリポジトリの文脈では、直接依存を明示する方に一貫性がある
- Expo の versions API（`relatedPackages`）は `babel-preset-expo` と `@babel/core` をバージョン追従対象として認識しており、package.json に明示していれば `expo install --fix` によるアップグレード時の自動追従や、`expo-doctor` / `expo install --check` によるバージョンずれの検知の対象になる。暗黙化するとこれらの恩恵を受けられない（`@expo/cli` の依存バージョン検証ロジックと実際の API レスポンスで確認済み）

バージョンは他の Expo 系 devDependencies に倣い tilde レンジ（`~57.0.2`）で固定した。`pnpm install` 後の lockfile 差分は importer の specifier 追加のみで、解決先バージョン自体は変わらない（既存の hoisted node_modules にあったものを明示しただけ）。

なお `@babel/core` は既に package.json に明示済みのため今回の対応は不要。

## レビューポイント

特になし。`pnpm --dir apps/sandbox run lint` / `test` で動作確認済み。

## Test plan

- [x] `pnpm install` でロックファイルが期待通り更新されることを確認
- [x] `pnpm --dir apps/sandbox run test` が全て pass することを確認
- [x] `pnpm --dir apps/sandbox run lint` が通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)