### PR TITLE
test(maestro): E2Eテストのディレクトリ構成を機能別に再編

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -31,7 +31,7 @@ jobs:
   # apps/sandbox/app.config.ts の expo-dev-client plugin（skipOnboarding 等）は常時有効だが、
   # このジョブはそもそも Dev Client を含まない e2e プロファイル（developmentClient: false）で
   # ビルドするため Dev Client 自体が混入しない。maestro test にも -e DEV_CLIENT を渡さない
-  # （Metro が無いため再接続ステップ自体が不要。apps/sandbox/.maestro/subflows/launch-app.yaml 参照）。
+  # （Metro が無いため再接続ステップ自体が不要。apps/sandbox/e2e/common/launch-app.yaml 参照）。
   # dependabot が @dependabot merge 等で直接 main に push した場合、actor が dependabot[bot]
   # になり secrets.EXPO_TOKEN が渡らず setup-eas が明示エラーで落ちる。main の E2E が
   # 恒常的に失敗してノイズになるのを避けるため、このケースはジョブごと skip する
@@ -142,7 +142,7 @@ jobs:
           adb shell settings put global transition_animation_scale 0
           adb shell settings put global animator_duration_scale 0
 
-      # アプリの起動は行わない。apps/sandbox/.maestro/smoke.yaml が呼ぶ subflows/launch-app.yaml
+      # アプリの起動は行わない。apps/sandbox/e2e/flows/home/smoke.yaml が呼ぶ common/launch-app.yaml
       # （-e DEV_CLIENT 未指定なので素の launchApp 分岐）を maestro test 自体が担う
       # （release / 埋め込み JS のため Metro も不要。install 済みであれば launchApp が起動できる）。
       - name: Install app
@@ -151,7 +151,7 @@ jobs:
       - name: Run Maestro E2E
         run: |
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
-          maestro test apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
+          maestro test apps/sandbox/e2e/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 
       # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
       # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
   # app.config.ts は expo-dev-client の config plugin（skipOnboarding 等）を常時有効化する
   # （E2E ビルド専用の分岐は無い。preview/production プロファイルにも適用されるが、それらは
   # Dev Client 自体を含まないビルドのため影響しない）。clearState 後の Metro への再接続は
-  # Maestro フロー側のディープリンク（apps/sandbox/.maestro/subflows/launch-app.yaml、
+  # Maestro フロー側のディープリンク（apps/sandbox/e2e/common/launch-app.yaml、
   # `-e DEV_CLIENT=true`）で行う。詳細は docs/maestro.md 参照。
   # ビルドは eas build --local を使うため EXPO_TOKEN（secrets）が必要。
   # dev-client debug ビルドには eas.json の development プロファイルを再利用する
@@ -209,7 +209,7 @@ jobs:
           # される（ビルドは上の eas build --local 済み）。素の adb install + expo start では dev-client が
           # Metro に接続せず黒画面になるため、接続確立を含む expo run:android の launch ロジックを再利用する。
           # （この初回起動時の接続は expo-cli 自体の機能であり defaultLaunchURL の有無に依存しない。
-          # 後続の Maestro フロー（apps/sandbox/.maestro/subflows/launch-app.yaml）による再起動時の
+          # 後続の Maestro フロー（apps/sandbox/e2e/common/launch-app.yaml）による再起動時の
           # 再接続は、この初回起動とは別に、独立コマンドの clearState → openLink のディープリンクで行う）
           # Metro はテスト中ずっと生かす必要があるためバックグラウンド実行（PID は cleanup 用に記録）。
           # --binary は絶対パスで渡す（pnpm --dir で cwd が apps/sandbox になり、リポジトリルート相対の
@@ -228,9 +228,9 @@ jobs:
           timeout 120 bash -c 'until curl -fsS http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done'
 
           # -e DEV_CLIENT=true により、smoke.yaml が呼ぶ launch-app.yaml が clearState → ディープリンク
-          # （openLink）で Metro へ再接続する（apps/sandbox/.maestro/subflows/launch-app.yaml 参照）。
+          # （openLink）で Metro へ再接続する（apps/sandbox/e2e/common/launch-app.yaml 参照）。
           # 失敗時のスクショ/ログは maestro の --debug-output（maestro-debug/）に出力される
-          maestro test -e DEV_CLIENT=true apps/sandbox/.maestro/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
+          maestro test -e DEV_CLIENT=true apps/sandbox/e2e/ --format junit --output maestro-report.xml --debug-output ./maestro-debug
 
       # maestro 失敗時も画面状態を確実に記録する（maestro --debug-output が空のことがあるため、
       # スクショ・ロケール・前面 activity・UI 階層テキストを adb で直接取得する）

--- a/apps/sandbox/app.config.ts
+++ b/apps/sandbox/app.config.ts
@@ -12,7 +12,7 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 // コード自体を含まないため、上記オプションは実質的に無関係で影響しない。
 //
 // Metro への接続（従来 defaultLaunchURL で焼き込んでいたもの）はビルド設定ではなく、
-// Maestro フロー側のディープリンク（apps/sandbox/.maestro/subflows/launch-app.yaml）で
+// Maestro フロー側のディープリンク（apps/sandbox/e2e/common/launch-app.yaml）で
 // 行う。詳細は docs/maestro.md を参照。
 export default ({ config }: ConfigContext): ExpoConfig => {
   return {

--- a/apps/sandbox/e2e/common/launch-app.yaml
+++ b/apps/sandbox/e2e/common/launch-app.yaml
@@ -1,8 +1,9 @@
 # アプリの起動をビルド種別で分岐する共通サブフロー。各テストフローは
-# `runFlow: subflows/launch-app.yaml` の1行を最初に置くだけでよい
+# `runFlow: ../../common/launch-app.yaml` の1行を最初に置くだけでよい
 # （分岐ロジック自体をテストフローごとに書かない。docs/maestro.md「フローの書き方」参照）。
-# maestro test はデフォルトでサブフォルダを走査しないため、このファイルも runFlow から
-# 明示的に呼ばれない限り単独のテストとしては実行されない。
+# apps/sandbox/e2e/config.yaml の `flows: - "flows/**"` により flows/ 配下のみが実行対象と
+# なるため、このファイル（common/ 配下）は runFlow から明示的に呼ばれない限り単独のテストとしては
+# 実行されない。
 appId: com.yamibeta.sandbox
 ---
 # Dev Client ビルド（-e DEV_CLIENT=true）は、クリーンな状態から launcher 画面を経由せず

--- a/apps/sandbox/e2e/config.yaml
+++ b/apps/sandbox/e2e/config.yaml
@@ -1,0 +1,2 @@
+flows:
+  - "flows/**"

--- a/apps/sandbox/e2e/flows/auth/auth.yaml
+++ b/apps/sandbox/e2e/flows/auth/auth.yaml
@@ -1,6 +1,6 @@
 # ログイン処理のサンプル（Protected Routes）の E2E フロー。
 # サインアウト時に auth/sign-in へ正しくフォールバックされるか、戻る操作で home へ戻れるかを検証する。
-# アプリの起動（Dev Client か release かの分岐を含む）は subflows/launch-app.yaml に切り出してある
+# アプリの起動（Dev Client か release かの分岐を含む）は common/launch-app.yaml に切り出してある
 # （docs/maestro.md「フローの書き方」参照）。
 # 表示テキストは lingui の <Trans>（sourceLocale=ja）。Maestro の assertVisible/tapOn は部分一致のため、
 # 裸の「サインイン」は使わない: サインイン画面のタイトル「サインイン」・ボタン「サインインする」・
@@ -12,7 +12,7 @@
 # 完全一致させ、本文を誤ってタップしないようにする。
 appId: com.yamibeta.sandbox
 ---
-- runFlow: subflows/launch-app.yaml
+- runFlow: ../../common/launch-app.yaml
 - assertVisible: "ホーム"
 - tapOn: "ログイン処理のサンプル"
 - assertVisible: "サインインする"

--- a/apps/sandbox/e2e/flows/home/smoke.yaml
+++ b/apps/sandbox/e2e/flows/home/smoke.yaml
@@ -7,10 +7,10 @@
 # 表示テキストは lingui の <Trans>（sourceLocale=ja）。
 appId: com.yamibeta.sandbox
 ---
-# アプリの起動（Dev Client か release かの分岐を含む）は subflows/launch-app.yaml に
+# アプリの起動（Dev Client か release かの分岐を含む）は common/launch-app.yaml に
 # 切り出してある。新しいフローを追加する場合もこの1行を最初に置く（docs/maestro.md
 # 「フローの書き方」参照）。分岐の詳細・過去の flaky 対応の経緯は launch-app.yaml のコメントを参照。
-- runFlow: subflows/launch-app.yaml
+- runFlow: ../../common/launch-app.yaml
 # ページの表示確認としてまず画面タイトル「ホーム」を assert し、続けて画面内の項目を確認する。
 - assertVisible: "ホーム" # Stack.Screen.Title / タブラベル（src/app/(tabs)/(home)/index.tsx）
 - assertVisible: "ナビゲーションパターン" # GroupedList の先頭項目

--- a/docs/maestro.md
+++ b/docs/maestro.md
@@ -32,10 +32,10 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
     **Maestro フロー側のディープリンク**で行う。`expo-dev-launcher` は
     `<scheme>://expo-development-client/?url=<encoded>` 形式の VIEW インテントを受け取ると、
     ビルド時の設定に関わらずそのURLのMetroへ接続する。この仕組みは起動方法を分岐する共通サブフロー
-    `apps/sandbox/.maestro/subflows/launch-app.yaml` に閉じており、Dev Client ビルドのときだけ
+    `apps/sandbox/e2e/common/launch-app.yaml` に閉じており、Dev Client ビルドのときだけ
     （`-e DEV_CLIENT=true`）実行される（「フローの書き方」参照）。
 - **フローは Dev Client あり/なしの両対応**。各テストフローは起動処理を自前で書かず
-  `runFlow: subflows/launch-app.yaml` の1行を呼ぶだけで、`-e DEV_CLIENT` を渡すかどうかだけで
+  `runFlow: ../../common/launch-app.yaml` の1行を呼ぶだけで、`-e DEV_CLIENT` を渡すかどうかだけで
   両方のビルド種別に対応する（「フローの書き方」参照）。
   Dev Client を含まない E2E（`e2e` プロファイル / release / 埋め込み JS）は
   `.github/workflows/e2e-main.yml` で main ブランチへの push 時に実行し、同じフローを再利用する。
@@ -68,24 +68,26 @@ jest-expo / Vitest のユニットテスト（[`testing.md`](./testing.md)）と
 | `apps/sandbox/.fingerprintignore` | dev-client APK キャッシュのキーに使う `@expo/fingerprint` の計算から除外するパス。ビルドで内容が変わり無駄な MISS を招く既知のファイル（`@react-native-masked-view/masked-view` の `AndroidManifest.xml` 等）を列挙 |
 | `apps/sandbox/eas.json` の `development` プロファイル | PR の dev-client debug E2E ビルドに再利用（`developmentClient: true` → Android は `:app:assembleDebug` = APK） |
 | `apps/sandbox/eas.json` の `e2e` プロファイル | 非 Dev Client 用（main の release E2E）ビルド設定（`developmentClient: false` / release で lint 除外 / `ios.simulator: true`） |
-| `apps/sandbox/.maestro/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（起動処理は `runFlow: subflows/launch-app.yaml` の1行に任せる。「フローの書き方」参照） |
-| `apps/sandbox/.maestro/subflows/launch-app.yaml` | 起動方法をビルド種別で分岐する共通サブフロー。`DEV_CLIENT` に応じて `clearState` → ディープリンク（`openLink`）による Metro 接続を行うか、素の `launchApp: {clearState: true}` を実行するかを切り替える。各テストフローはこれを `runFlow` で呼ぶだけでよく、分岐ロジックを重複して書かない。`maestro test` はデフォルトでサブフォルダを走査しないため単独実行はされない |
+| `apps/sandbox/e2e/flows/**/*.yaml` | Maestro フロー。`appId: com.yamibeta.sandbox`。プラットフォーム・ビルド種別非依存（起動処理は `runFlow: ../../common/launch-app.yaml` の1行に任せる。「フローの書き方」参照） |
+| `apps/sandbox/e2e/common/launch-app.yaml` | 起動方法をビルド種別で分岐する共通サブフロー。`DEV_CLIENT` に応じて `clearState` → ディープリンク（`openLink`）による Metro 接続を行うか、素の `launchApp: {clearState: true}` を実行するかを切り替える。各テストフローはこれを `runFlow` で呼ぶだけでよく、分岐ロジックを重複して書かない。`apps/sandbox/e2e/config.yaml` の `flows: - "flows/**"` により `flows/` 配下のみが実行対象となるため、`common/` 配下は単独実行の対象から除外される |
 | `.github/workflows/e2e.yml` | PR ごとに「fingerprint 計算 → APK キャッシュ復元／（ミス時）`eas build --local --profile development` → emulator 起動 → `expo run:android --binary <APK>`（install→Metro→`adb reverse`→dev-client 起動）→ `maestro test -e DEV_CLIENT=true`」を実行 |
 | `.github/workflows/e2e-main.yml` | main への push ごとに、release E2E ジョブ（`eas build --local --profile e2e` → install → `maestro test`。Dev Client が無いため `-e DEV_CLIENT` は渡さない）と dev-client APK 温めジョブ（`warm-devclient-cache`。fingerprint → `eas build --local --profile development` → キャッシュ保存。build のみ）を並列実行 |
 
 ## フローの書き方
 
-`apps/sandbox/.maestro/` に `*.yaml` を追加する（機能ごとに co-location）。アプリの起動処理は
-自前で書かず、共通サブフロー `runFlow: subflows/launch-app.yaml` を最初に置くだけでよい:
+`apps/sandbox/e2e/flows/<機能名>/` に `*.yaml` を追加する（機能ごとに co-location）。
+`apps/sandbox/e2e/config.yaml` の `flows: - "flows/**"` により `flows/` 配下が実行対象になる。
+アプリの起動処理は自前で書かず、共通サブフロー `runFlow: ../../common/launch-app.yaml` を
+最初に置くだけでよい:
 
 ```yaml
 appId: com.yamibeta.sandbox
 ---
-- runFlow: subflows/launch-app.yaml
+- runFlow: ../../common/launch-app.yaml
 - assertVisible: "ホーム"
 ```
 
-`launch-app.yaml`（`apps/sandbox/.maestro/subflows/launch-app.yaml`）が `DEV_CLIENT` で
+`launch-app.yaml`（`apps/sandbox/e2e/common/launch-app.yaml`）が `DEV_CLIENT` で
 起動方法を分岐する:
 
 ```yaml
@@ -171,7 +173,7 @@ Maestro CLI が未インストールなら `curl -fsSL "https://get.maestro.mobi
 pnpm --dir apps/sandbox exec expo run:android
 
 # 2. 別ターミナルでフローを実行する（-e DEV_CLIENT=true でディープリンクによる Metro 再接続が有効になる）
-maestro test -e DEV_CLIENT=true apps/sandbox/.maestro/
+maestro test -e DEV_CLIENT=true apps/sandbox/e2e/
 ```
 
 > CI（`e2e.yml`）は同じ dev-client debug ビルドを `eas build --local --profile development` で作り
@@ -198,7 +200,7 @@ E2E_DEFAULT_LOCALE=ja pnpm --dir apps/sandbox exec eas build --local --profile e
 adb install -r apps/sandbox/build-output/sandbox-e2e.apk
 
 # 3. 同じフローを実行（Metro 不要、-e DEV_CLIENT は渡さない）
-maestro test apps/sandbox/.maestro/
+maestro test apps/sandbox/e2e/
 ```
 
 ## CI（`.github/workflows/e2e.yml`）
@@ -220,7 +222,7 @@ maestro test apps/sandbox/.maestro/
   `expo start` では Metro に接続せず黒画面になる）、`--binary` で Gradle ビルドのみスキップして
   このロジックを再利用する。dev-client 起動後の Metro 接続確立は run:android が担い、maestro の
   `clearState` で状態がクリアされた後の再接続は `-e DEV_CLIENT=true` によるディープリンク
-  （`apps/sandbox/.maestro/subflows/launch-app.yaml`）が担う。
+  （`apps/sandbox/e2e/common/launch-app.yaml`）が担う。
 - `E2E_DEFAULT_LOCALE` は fingerprint 計算・ビルド・`expo run:android` の各ステップに
   step `env` として同じ値（`ja`）を渡す。dev-client では `Constants.expoConfig` が Metro 配信の
   manifest 由来のため、run:android が起動する Metro にも渡して app.config を同条件で評価させる（既定言語が `ja`）。
@@ -261,7 +263,7 @@ maestro test apps/sandbox/.maestro/
     （Metro が無いため再接続ステップが不要。渡さなければ `runFlow` がスキップされるだけで安全）。
     EAS の認証には `.github/actions/setup-eas`（`secrets.EXPO_TOKEN`）を使う。
   - Metro は使わないため、build→install→起動の自動化は無い。ビルドした APK を `adb install` するだけで、
-    アプリの起動自体は `apps/sandbox/.maestro/smoke.yaml` が呼ぶ `subflows/launch-app.yaml`
+    アプリの起動自体は `apps/sandbox/e2e/flows/home/smoke.yaml` が呼ぶ `common/launch-app.yaml`
     （`-e DEV_CLIENT` 未指定なので素の `launchApp` 分岐）に任せる。
   - artifact 名は `maestro-results-${{ github.sha }}`（push イベントには PR 番号が無いため）。
     失敗解析用にビルド済み APK も artifact に含める。
@@ -287,7 +289,7 @@ maestro test apps/sandbox/.maestro/
   `-e DEV_CLIENT=true` を渡す。非 Dev Client なら `e2e` プロファイル（`ios.simulator: true`）を
   `eas build --local --platform ios` でビルドする。
 - ワークフローに macOS ランナーの `e2e-ios` ジョブを追加し、simulator を起動 → 上記でビルド/install →
-  `maestro test` を実行する。フロー（`.maestro/*.yaml`）はそのまま再利用できる。
+  `maestro test` を実行する。フロー（`e2e/flows/**/*.yaml`）はそのまま再利用できる。
 - iOS simulator は `localhost` が直接ホストを指すため `adb reverse` は不要（`expo run:ios` 経由なら
-  Metro 接続も自動）。`apps/sandbox/.maestro/subflows/launch-app.yaml` のディープリンクも
+  Metro 接続も自動）。`apps/sandbox/e2e/common/launch-app.yaml` のディープリンクも
   `http://localhost:8081` のまま Metro に接続できる。


### PR DESCRIPTION
## 概要

Maestro E2E テストのディレクトリ構成を `apps/sandbox/.maestro/` から機能別サブディレクトリを
持つ `apps/sandbox/e2e/` に変更する。

```
e2e/
├── config.yaml         # flows: - "flows/**"
├── flows/
│   ├── auth/auth.yaml
│   └── home/smoke.yaml
└── common/launch-app.yaml
```

ファイル名（`auth.yaml`/`smoke.yaml`/`launch-app.yaml`）やテストロジック自体は変更していない。

## 背景・動機

既存の `.maestro/` はフラットな構成で、共有起動処理（`subflows/launch-app.yaml`）が
`maestro test` のデフォルト挙動（サブフォルダを走査しない）に暗黙的に依存していた。
実際の OSS プロジェクト（Bluesky 等）の Maestro 構成を調査し、機能ごとにディレクトリを
分ける・共有flowの除外を `config.yaml` で明示するという一般的なパターンに寄せることにした。

## アプローチ

- 共有サブフローの置き場所は当初 `utils/` を検討したが、Maestro 公式ドキュメント
  （repository-configuration、公式ブログ）を一次ソースで確認したところ、`utils/` は
  `runScript` で呼ぶ JS スクリプトの置き場として予約されており、`runFlow` で呼ぶ共有
  flow（yaml）の置き場所として公式ブログが明示するのは `common/` だったため、これを採用した。
- `config.yaml` が必要な理由: Maestro CLI（`WorkspaceExecutionPlanner`）は `config.yaml` の
  `flows` キー（デフォルトは `"*"` で、CLI に渡したディレクトリ直下の1階層のみにマッチ）で
  実行対象をフィルタする。`flows/auth/`, `flows/home/` のように2階層目に flow を置く新構成
  では `flows: - "flows/**"` を明示しないと検出されない。この glob により `common/` 配下は
  自動的にスタンドアロン実行の対象から除外される。
- CI（`e2e.yml`/`e2e-main.yml`）の実行パスと `docs/maestro.md`、`app.config.ts` のコメントを
  新構成に合わせて更新した。

## レビューポイント

- ローカルで Metro + emulator + `-e DEV_CLIENT=true` により `maestro test apps/sandbox/e2e/`
  を実行し、`smoke`/`auth` 両フローが Pass することを確認済み（`config.yaml` の flow discovery、
  `runFlow` の相対パス解決が正しく機能することも合わせて確認済み）。
- 最終的な担保は本 PR の CI（`e2e.yml`）で行われる想定。